### PR TITLE
Exclude leading and trailing whitespace from `implicit_string`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -371,7 +371,7 @@ module.exports = grammar({
 
     /* Strings */
 
-    implicit_string: ($) => token(/.*/),
+    implicit_string: ($) => token(/\S(.*\S)?/),
 
     string: ($) =>
       seq(


### PR DESCRIPTION
Fixes #22 