### PR TITLE
separate key and sleep action name from opening parentheses

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -302,14 +302,16 @@ module.exports = grammar({
 
     key_action: ($) =>
       seq(
-        "key(",
+        "key",
+        "(",
         field("arguments", $._implicit_string_argument),
         ")"
       ),
 
     sleep_action: ($) =>
       seq(
-        "sleep(",
+        "sleep",
+        "(",
         field("arguments", $._implicit_string_argument),
         ")"
       ),


### PR DESCRIPTION
For Cursorless we really need the name as a separate child/node so that we can extract it.
This will work adequately until we have #13 and can unify all the implementations