### PR TITLE
Remove unused operator rule

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -313,8 +313,6 @@ module.exports = grammar({
     parenthesized_expression: ($) =>
       prec(PREC.parenthesized_expression, seq("(", $.expression, ")")),
 
-    operator: ($) => /[\p{Dash_Punctuation}\p{Math_Symbol}]+/,
-
     binary_operator: ($) => {
       const table = [
         [prec.left, "+", PREC.plus],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -998,10 +998,6 @@
         ]
       }
     },
-    "operator": {
-      "type": "PATTERN",
-      "value": "[\\p{Dash_Punctuation}\\p{Math_Symbol}]+"
-    },
     "binary_operator": {
       "type": "CHOICE",
       "members": [


### PR DESCRIPTION
This rule was unused, and was causing the generator to crash on newer versions of tree-sitter