### PR TITLE
Add support for if and for statements in Talon script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,8 @@ src/*.json linguist-generated
 src/parser.c linguist-generated
 src/tree_sitter/* linguist-generated
 
+test/corpus/crlf.txt eol=crlf
+
 bindings/** linguist-generated
 binding.gyp linguist-generated
 setup.py linguist-generated

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ dist/
 
 /test/data/
 *.log
+
+parser.exp
+parser.lib

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Tested with:
 
 - [talonhub/community]
 - [AndreasArvidsson/andreas-talon]
-- [phillco/talon-axkit]
 - [nriley/talon_community]
+- [phillco/talon-axkit]
 
-If you would like to include your Talon user directory as part of the tests, please submit a pull request adding the relevant information to [`script/parse-examples`](script/parse-examples#L32-L37) and this file.
+If you would like to include your Talon user directory as part of the tests, please submit a pull request adding the relevant information to [`package.json/tree-sitter-talon/tested-with`](package.json#73) and this file.
 
 [tree-sitter]: https://github.com/tree-sitter/tree-sitter
 [talon-wiki]: https://talon.wiki/customization/talon-files/

--- a/grammar.js
+++ b/grammar.js
@@ -276,6 +276,26 @@ module.exports = grammar({
       choice(
         $.assignment_statement,
         $.expression_statement,
+        $.if_statement,
+        $.for_statement,
+      ),
+
+    if_statement: ($) =>
+      seq(
+        "if",
+        field("condition", $.expression),
+        ":",
+        field("body", $.statement),
+      ),
+
+    for_statement: ($) =>
+      seq(
+        "for",
+        field("name", $.identifier),
+        "in",
+        field("value", $.expression),
+        ":",
+        field("body", $.statement),
       ),
 
     assignment_statement: ($) =>

--- a/package.json
+++ b/package.json
@@ -71,10 +71,10 @@
   ],
   "tree-sitter-talon": {
     "tested-with": [
-      "github:AndreasArvidsson/andreas-talon#43811bae4c1a75f2ecd29240891f6612a1b7cec5",
-      "github:nriley/talon_community#1ff0e36f47689193be1d8909b9935f7c7004a045",
-      "github:phillco/talon-axkit#8eecc78b2de65b68123a6e1eae72a5a790a4e407",
-      "github:talonhub/community#93c9261c240078c46290ae1a500f2c9cfc749833"
+      "github:AndreasArvidsson/andreas-talon#33d1d2d2b0931e65d1ce3a7a654c667a77947ff7",
+      "github:nriley/talon_community#51bc9087a723af0c6b8587cccea14068280fafee",
+      "github:phillco/talon-axkit#9fc628255f6fc7870a02b107d6eab079531557e1",
+      "github:talonhub/community#4eadd8f457500a841d739fc4823c4157f357c36d"
     ]
   }
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -875,6 +875,84 @@
         {
           "type": "SYMBOL",
           "name": "expression_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "if_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "for_statement"
+        }
+      ]
+    },
+    "if_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "if"
+        },
+        {
+          "type": "FIELD",
+          "name": "condition",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expression"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "statement"
+          }
+        }
+      ]
+    },
+    "for_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "for"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "in"
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expression"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "statement"
+          }
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -116,6 +116,14 @@
       {
         "type": "expression_statement",
         "named": true
+      },
+      {
+        "type": "for_statement",
+        "named": true
+      },
+      {
+        "type": "if_statement",
+        "named": true
       }
     ]
   },
@@ -488,6 +496,42 @@
     }
   },
   {
+    "type": "for_statement",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "statement",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "gamepad_binding",
     "named": true,
     "fields": {
@@ -533,6 +577,32 @@
     "type": "identifier",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "if_statement",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "statement",
+            "named": true
+          }
+        ]
+      },
+      "condition": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      }
+    }
   },
   {
     "type": "interpolation",
@@ -1303,12 +1373,24 @@
     "named": true
   },
   {
+    "type": "for",
+    "named": false
+  },
+  {
     "type": "gamepad(",
+    "named": false
+  },
+  {
+    "type": "if",
     "named": false
   },
   {
     "type": "implicit_string",
     "named": true
+  },
+  {
+    "type": "in",
+    "named": false
   },
   {
     "type": "integer",

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,15 +5,15 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 207
+#define STATE_COUNT 227
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 117
+#define SYMBOL_COUNT 122
 #define ALIAS_COUNT 1
-#define TOKEN_COUNT 52
+#define TOKEN_COUNT 55
 #define EXTERNAL_TOKEN_COUNT 7
-#define FIELD_COUNT 10
-#define MAX_ALIAS_SEQUENCE_LENGTH 5
-#define PRODUCTION_ID_COUNT 13
+#define FIELD_COUNT 14
+#define MAX_ALIAS_SEQUENCE_LENGTH 6
+#define PRODUCTION_ID_COUNT 15
 
 enum ts_symbol_identifiers {
   sym_comment = 1,
@@ -44,95 +44,100 @@ enum ts_symbol_identifiers {
   anon_sym_parrot_LPAREN = 26,
   sym_settings_binding = 27,
   sym_tag_binding = 28,
-  anon_sym_EQ = 29,
-  anon_sym_SLASH = 30,
-  anon_sym_PERCENT = 31,
-  anon_sym_or = 32,
-  anon_sym_key_LPAREN = 33,
-  anon_sym_sleep_LPAREN = 34,
-  aux_sym__implicit_string_argument_token1 = 35,
-  anon_sym_LPAREN2 = 36,
-  anon_sym_COMMA = 37,
-  aux_sym_identifier_token1 = 38,
-  sym_integer = 39,
-  sym_float = 40,
-  sym_implicit_string = 41,
-  anon_sym_LBRACE_LBRACE = 42,
-  anon_sym_RBRACE_RBRACE = 43,
-  sym_string_escape_sequence = 44,
-  sym__not_escapesequence = 45,
-  sym__newline = 46,
-  sym__indent = 47,
-  sym__dedent = 48,
-  sym__string_start = 49,
-  sym_string_content = 50,
-  sym__string_end = 51,
-  sym_source_file = 52,
-  sym_matches = 53,
-  sym_match_modifier = 54,
-  sym_match = 55,
-  sym_declarations = 56,
-  sym_declaration = 57,
-  sym_command_declaration = 58,
-  sym_app_declaration = 59,
-  sym_face_declaration = 60,
-  sym_deck_declaration = 61,
-  sym_gamepad_declaration = 62,
-  sym_noise_declaration = 63,
-  sym_parrot_declaration = 64,
-  sym_tag_import_declaration = 65,
-  sym_key_binding_declaration = 66,
-  sym_settings_declaration = 67,
-  sym_rule = 68,
-  sym__optional_choice = 69,
-  sym_choice = 70,
-  sym__optional_anchor = 71,
-  sym__optional_seq = 72,
-  sym_seq = 73,
-  sym__primary_rule = 74,
-  sym_word = 75,
-  sym_list = 76,
-  sym_capture = 77,
-  sym_optional = 78,
-  sym_repeat = 79,
-  sym_repeat1 = 80,
-  sym_parenthesized_rule = 81,
-  sym_app_binding = 82,
-  sym_face_binding = 83,
-  sym_deck_binding = 84,
-  sym_gamepad_binding = 85,
-  sym_noise_binding = 86,
-  sym_parrot_binding = 87,
-  sym__statements = 88,
-  sym_block = 89,
-  sym_statement = 90,
-  sym_assignment_statement = 91,
-  sym_expression_statement = 92,
-  sym_expression = 93,
-  sym_variable = 94,
-  sym_parenthesized_expression = 95,
-  sym_binary_operator = 96,
-  sym_unary_operator = 97,
-  sym_key_action = 98,
-  sym_sleep_action = 99,
-  sym__implicit_string_argument = 100,
-  sym_action = 101,
-  sym_argument_list = 102,
-  sym_identifier = 103,
-  sym_string = 104,
-  sym_interpolation = 105,
-  sym__escape_interpolation = 106,
-  sym__not_interpolation = 107,
-  aux_sym_matches_repeat1 = 108,
-  aux_sym_matches_repeat2 = 109,
-  aux_sym_match_repeat1 = 110,
-  aux_sym_declarations_repeat1 = 111,
-  aux_sym_choice_repeat1 = 112,
-  aux_sym_seq_repeat1 = 113,
-  aux_sym_block_repeat1 = 114,
-  aux_sym_argument_list_repeat1 = 115,
-  aux_sym_string_repeat1 = 116,
-  alias_sym_key_binding = 117,
+  anon_sym_if = 29,
+  anon_sym_for = 30,
+  anon_sym_in = 31,
+  anon_sym_EQ = 32,
+  anon_sym_SLASH = 33,
+  anon_sym_PERCENT = 34,
+  anon_sym_or = 35,
+  anon_sym_key_LPAREN = 36,
+  anon_sym_sleep_LPAREN = 37,
+  aux_sym__implicit_string_argument_token1 = 38,
+  anon_sym_LPAREN2 = 39,
+  anon_sym_COMMA = 40,
+  aux_sym_identifier_token1 = 41,
+  sym_integer = 42,
+  sym_float = 43,
+  sym_implicit_string = 44,
+  anon_sym_LBRACE_LBRACE = 45,
+  anon_sym_RBRACE_RBRACE = 46,
+  sym_string_escape_sequence = 47,
+  sym__not_escapesequence = 48,
+  sym__newline = 49,
+  sym__indent = 50,
+  sym__dedent = 51,
+  sym__string_start = 52,
+  sym_string_content = 53,
+  sym__string_end = 54,
+  sym_source_file = 55,
+  sym_matches = 56,
+  sym_match_modifier = 57,
+  sym_match = 58,
+  sym_declarations = 59,
+  sym_declaration = 60,
+  sym_command_declaration = 61,
+  sym_app_declaration = 62,
+  sym_face_declaration = 63,
+  sym_deck_declaration = 64,
+  sym_gamepad_declaration = 65,
+  sym_noise_declaration = 66,
+  sym_parrot_declaration = 67,
+  sym_tag_import_declaration = 68,
+  sym_key_binding_declaration = 69,
+  sym_settings_declaration = 70,
+  sym_rule = 71,
+  sym__optional_choice = 72,
+  sym_choice = 73,
+  sym__optional_anchor = 74,
+  sym__optional_seq = 75,
+  sym_seq = 76,
+  sym__primary_rule = 77,
+  sym_word = 78,
+  sym_list = 79,
+  sym_capture = 80,
+  sym_optional = 81,
+  sym_repeat = 82,
+  sym_repeat1 = 83,
+  sym_parenthesized_rule = 84,
+  sym_app_binding = 85,
+  sym_face_binding = 86,
+  sym_deck_binding = 87,
+  sym_gamepad_binding = 88,
+  sym_noise_binding = 89,
+  sym_parrot_binding = 90,
+  sym__statements = 91,
+  sym_block = 92,
+  sym_statement = 93,
+  sym_if_statement = 94,
+  sym_for_statement = 95,
+  sym_assignment_statement = 96,
+  sym_expression_statement = 97,
+  sym_expression = 98,
+  sym_variable = 99,
+  sym_parenthesized_expression = 100,
+  sym_binary_operator = 101,
+  sym_unary_operator = 102,
+  sym_key_action = 103,
+  sym_sleep_action = 104,
+  sym__implicit_string_argument = 105,
+  sym_action = 106,
+  sym_argument_list = 107,
+  sym_identifier = 108,
+  sym_string = 109,
+  sym_interpolation = 110,
+  sym__escape_interpolation = 111,
+  sym__not_interpolation = 112,
+  aux_sym_matches_repeat1 = 113,
+  aux_sym_matches_repeat2 = 114,
+  aux_sym_match_repeat1 = 115,
+  aux_sym_declarations_repeat1 = 116,
+  aux_sym_choice_repeat1 = 117,
+  aux_sym_seq_repeat1 = 118,
+  aux_sym_block_repeat1 = 119,
+  aux_sym_argument_list_repeat1 = 120,
+  aux_sym_string_repeat1 = 121,
+  alias_sym_key_binding = 122,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -165,6 +170,9 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_parrot_LPAREN] = "parrot(",
   [sym_settings_binding] = "settings_binding",
   [sym_tag_binding] = "tag_binding",
+  [anon_sym_if] = "if",
+  [anon_sym_for] = "for",
+  [anon_sym_in] = "in",
   [anon_sym_EQ] = "=",
   [anon_sym_SLASH] = "operator",
   [anon_sym_PERCENT] = "operator",
@@ -227,6 +235,8 @@ static const char * const ts_symbol_names[] = {
   [sym__statements] = "_statements",
   [sym_block] = "block",
   [sym_statement] = "statement",
+  [sym_if_statement] = "if_statement",
+  [sym_for_statement] = "for_statement",
   [sym_assignment_statement] = "assignment_statement",
   [sym_expression_statement] = "expression_statement",
   [sym_expression] = "expression",
@@ -286,6 +296,9 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_parrot_LPAREN] = anon_sym_parrot_LPAREN,
   [sym_settings_binding] = sym_settings_binding,
   [sym_tag_binding] = sym_tag_binding,
+  [anon_sym_if] = anon_sym_if,
+  [anon_sym_for] = anon_sym_for,
+  [anon_sym_in] = anon_sym_in,
   [anon_sym_EQ] = anon_sym_EQ,
   [anon_sym_SLASH] = anon_sym_SLASH,
   [anon_sym_PERCENT] = anon_sym_SLASH,
@@ -348,6 +361,8 @@ static const TSSymbol ts_symbol_map[] = {
   [sym__statements] = sym__statements,
   [sym_block] = sym_block,
   [sym_statement] = sym_statement,
+  [sym_if_statement] = sym_if_statement,
+  [sym_for_statement] = sym_for_statement,
   [sym_assignment_statement] = sym_assignment_statement,
   [sym_expression_statement] = sym_expression_statement,
   [sym_expression] = sym_expression,
@@ -493,6 +508,18 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   [sym_tag_binding] = {
     .visible = true,
     .named = true,
+  },
+  [anon_sym_if] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_for] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_in] = {
+    .visible = true,
+    .named = false,
   },
   [anon_sym_EQ] = {
     .visible = true,
@@ -744,6 +771,14 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = true,
     .supertype = true,
   },
+  [sym_if_statement] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_for_statement] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_assignment_statement] = {
     .visible = true,
     .named = true,
@@ -858,27 +893,35 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
 enum ts_field_identifiers {
   field_action_name = 1,
   field_arguments = 2,
-  field_capture_name = 3,
-  field_expression = 4,
-  field_left = 5,
-  field_list_name = 6,
-  field_modifiers = 7,
-  field_operator = 8,
-  field_right = 9,
-  field_variable_name = 10,
+  field_body = 3,
+  field_capture_name = 4,
+  field_condition = 5,
+  field_expression = 6,
+  field_left = 7,
+  field_list_name = 8,
+  field_modifiers = 9,
+  field_name = 10,
+  field_operator = 11,
+  field_right = 12,
+  field_value = 13,
+  field_variable_name = 14,
 };
 
 static const char * const ts_field_names[] = {
   [0] = NULL,
   [field_action_name] = "action_name",
   [field_arguments] = "arguments",
+  [field_body] = "body",
   [field_capture_name] = "capture_name",
+  [field_condition] = "condition",
   [field_expression] = "expression",
   [field_left] = "left",
   [field_list_name] = "list_name",
   [field_modifiers] = "modifiers",
+  [field_name] = "name",
   [field_operator] = "operator",
   [field_right] = "right",
+  [field_value] = "value",
   [field_variable_name] = "variable_name",
 };
 
@@ -894,6 +937,8 @@ static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [10] = {.index = 9, .length = 2},
   [11] = {.index = 11, .length = 3},
   [12] = {.index = 14, .length = 3},
+  [13] = {.index = 17, .length = 2},
+  [14] = {.index = 19, .length = 3},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
@@ -924,6 +969,13 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
     {field_left, 1},
     {field_modifiers, 0},
     {field_right, 3},
+  [17] =
+    {field_body, 3},
+    {field_condition, 1},
+  [19] =
+    {field_body, 5},
+    {field_name, 1},
+    {field_value, 3},
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
@@ -973,36 +1025,36 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [17] = 17,
   [18] = 18,
   [19] = 19,
-  [20] = 19,
-  [21] = 21,
+  [20] = 18,
+  [21] = 19,
   [22] = 22,
   [23] = 23,
-  [24] = 22,
+  [24] = 23,
   [25] = 25,
   [26] = 26,
   [27] = 27,
-  [28] = 23,
+  [28] = 27,
   [29] = 29,
   [30] = 30,
-  [31] = 30,
-  [32] = 32,
+  [31] = 31,
+  [32] = 31,
   [33] = 33,
-  [34] = 32,
-  [35] = 33,
+  [34] = 34,
+  [35] = 35,
   [36] = 36,
-  [37] = 29,
+  [37] = 37,
   [38] = 38,
   [39] = 39,
-  [40] = 36,
-  [41] = 38,
-  [42] = 42,
-  [43] = 43,
-  [44] = 44,
-  [45] = 45,
-  [46] = 46,
-  [47] = 47,
-  [48] = 48,
-  [49] = 49,
+  [40] = 40,
+  [41] = 41,
+  [42] = 38,
+  [43] = 39,
+  [44] = 33,
+  [45] = 34,
+  [46] = 35,
+  [47] = 40,
+  [48] = 37,
+  [49] = 41,
   [50] = 50,
   [51] = 51,
   [52] = 52,
@@ -1027,26 +1079,26 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [71] = 71,
   [72] = 72,
   [73] = 73,
-  [74] = 72,
+  [74] = 74,
   [75] = 75,
   [76] = 76,
-  [77] = 75,
+  [77] = 77,
   [78] = 78,
   [79] = 79,
   [80] = 80,
   [81] = 81,
   [82] = 82,
-  [83] = 83,
-  [84] = 52,
-  [85] = 82,
-  [86] = 58,
-  [87] = 48,
-  [88] = 88,
-  [89] = 89,
+  [83] = 69,
+  [84] = 84,
+  [85] = 84,
+  [86] = 86,
+  [87] = 87,
+  [88] = 87,
+  [89] = 58,
   [90] = 90,
-  [91] = 91,
-  [92] = 92,
-  [93] = 93,
+  [91] = 57,
+  [92] = 59,
+  [93] = 71,
   [94] = 94,
   [95] = 95,
   [96] = 96,
@@ -1056,56 +1108,56 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [100] = 100,
   [101] = 101,
   [102] = 102,
-  [103] = 76,
-  [104] = 91,
-  [105] = 80,
+  [103] = 97,
+  [104] = 104,
+  [105] = 105,
   [106] = 106,
   [107] = 107,
   [108] = 108,
   [109] = 109,
-  [110] = 83,
-  [111] = 99,
-  [112] = 102,
+  [110] = 110,
+  [111] = 111,
+  [112] = 112,
   [113] = 113,
   [114] = 114,
-  [115] = 95,
-  [116] = 88,
-  [117] = 117,
+  [115] = 114,
+  [116] = 90,
+  [117] = 77,
   [118] = 118,
   [119] = 119,
-  [120] = 101,
-  [121] = 114,
-  [122] = 89,
-  [123] = 119,
-  [124] = 94,
-  [125] = 100,
-  [126] = 113,
-  [127] = 98,
-  [128] = 93,
-  [129] = 97,
-  [130] = 90,
-  [131] = 96,
-  [132] = 92,
-  [133] = 133,
+  [120] = 120,
+  [121] = 121,
+  [122] = 122,
+  [123] = 123,
+  [124] = 98,
+  [125] = 96,
+  [126] = 111,
+  [127] = 112,
+  [128] = 104,
+  [129] = 129,
+  [130] = 122,
+  [131] = 131,
+  [132] = 132,
+  [133] = 129,
   [134] = 134,
-  [135] = 135,
-  [136] = 136,
-  [137] = 137,
-  [138] = 138,
-  [139] = 139,
-  [140] = 140,
+  [135] = 109,
+  [136] = 131,
+  [137] = 105,
+  [138] = 108,
+  [139] = 113,
+  [140] = 123,
   [141] = 141,
-  [142] = 142,
-  [143] = 143,
-  [144] = 144,
-  [145] = 145,
-  [146] = 146,
-  [147] = 147,
-  [148] = 148,
+  [142] = 107,
+  [143] = 100,
+  [144] = 101,
+  [145] = 132,
+  [146] = 106,
+  [147] = 99,
+  [148] = 110,
   [149] = 149,
   [150] = 150,
   [151] = 151,
-  [152] = 150,
+  [152] = 152,
   [153] = 153,
   [154] = 154,
   [155] = 155,
@@ -1113,26 +1165,26 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [157] = 157,
   [158] = 158,
   [159] = 159,
-  [160] = 154,
+  [160] = 160,
   [161] = 161,
   [162] = 162,
-  [163] = 156,
+  [163] = 163,
   [164] = 164,
   [165] = 165,
-  [166] = 166,
+  [166] = 161,
   [167] = 167,
   [168] = 168,
-  [169] = 169,
+  [169] = 163,
   [170] = 170,
   [171] = 171,
   [172] = 172,
   [173] = 173,
   [174] = 174,
   [175] = 175,
-  [176] = 176,
+  [176] = 175,
   [177] = 177,
   [178] = 178,
-  [179] = 179,
+  [179] = 174,
   [180] = 180,
   [181] = 181,
   [182] = 182,
@@ -1149,17 +1201,37 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [193] = 193,
   [194] = 194,
   [195] = 195,
-  [196] = 194,
+  [196] = 196,
   [197] = 197,
   [198] = 198,
   [199] = 199,
   [200] = 200,
-  [201] = 201,
+  [201] = 196,
   [202] = 202,
   [203] = 203,
-  [204] = 197,
-  [205] = 189,
-  [206] = 206,
+  [204] = 204,
+  [205] = 205,
+  [206] = 197,
+  [207] = 207,
+  [208] = 208,
+  [209] = 209,
+  [210] = 210,
+  [211] = 211,
+  [212] = 212,
+  [213] = 213,
+  [214] = 214,
+  [215] = 215,
+  [216] = 216,
+  [217] = 217,
+  [218] = 218,
+  [219] = 219,
+  [220] = 220,
+  [221] = 210,
+  [222] = 222,
+  [223] = 223,
+  [224] = 224,
+  [225] = 194,
+  [226] = 226,
 };
 
 static TSCharacterRange aux_sym_word_token1_character_set_1[] = {
@@ -1293,499 +1365,511 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(103);
+      if (eof) ADVANCE(109);
       ADVANCE_MAP(
-        '#', 106,
-        '$', 219,
-        '%', 243,
-        '(', 251,
-        ')', 232,
-        '*', 229,
-        '+', 230,
-        ',', 252,
-        '-', 209,
-        '.', 80,
-        '/', 242,
-        '0', 255,
-        ':', 216,
-        '<', 225,
-        '=', 241,
-        '>', 226,
-        '[', 227,
+        '#', 112,
+        '$', 228,
+        '%', 257,
+        '(', 265,
+        ')', 241,
+        '*', 238,
+        '+', 239,
+        ',', 266,
+        '-', 218,
+        '.', 86,
+        '/', 256,
+        '0', 269,
+        ':', 225,
+        '<', 234,
+        '=', 255,
+        '>', 235,
+        '[', 236,
       );
-      if (lookahead == '\\') SKIP(95);
-      if (lookahead == ']') ADVANCE(228);
-      if (lookahead == '^') ADVANCE(218);
-      if (lookahead == 'a') ADVANCE(60);
-      if (lookahead == 'd') ADVANCE(46);
-      if (lookahead == 'f') ADVANCE(41);
-      if (lookahead == 'g') ADVANCE(37);
-      if (lookahead == 'k') ADVANCE(47);
-      if (lookahead == 'n') ADVANCE(62);
-      if (lookahead == 'o') ADVANCE(67);
-      if (lookahead == 'p') ADVANCE(39);
-      if (lookahead == 's') ADVANCE(48);
-      if (lookahead == 't') ADVANCE(38);
-      if (lookahead == '{') ADVANCE(222);
-      if (lookahead == '|') ADVANCE(217);
-      if (lookahead == '}') ADVANCE(224);
+      if (lookahead == '\\') SKIP(101);
+      if (lookahead == ']') ADVANCE(237);
+      if (lookahead == '^') ADVANCE(227);
+      if (lookahead == 'a') ADVANCE(64);
+      if (lookahead == 'd') ADVANCE(49);
+      if (lookahead == 'f') ADVANCE(43);
+      if (lookahead == 'g') ADVANCE(40);
+      if (lookahead == 'i') ADVANCE(57);
+      if (lookahead == 'k') ADVANCE(50);
+      if (lookahead == 'n') ADVANCE(67);
+      if (lookahead == 'o') ADVANCE(72);
+      if (lookahead == 'p') ADVANCE(44);
+      if (lookahead == 's') ADVANCE(51);
+      if (lookahead == 't') ADVANCE(41);
+      if (lookahead == '{') ADVANCE(231);
+      if (lookahead == '|') ADVANCE(226);
+      if (lookahead == '}') ADVANCE(233);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ' ||
           lookahead == 0x200b ||
           lookahead == 0x2060 ||
-          lookahead == 0xfeff) SKIP(100);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(256);
+          lookahead == 0xfeff) SKIP(106);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(270);
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(272);
+      if (lookahead == '\n') SKIP(20);
       END_STATE();
     case 2:
-      if (lookahead == '\n') SKIP(17);
+      if (lookahead == '\n') SKIP(20);
+      if (lookahead == '\r') SKIP(1);
       END_STATE();
     case 3:
-      if (lookahead == '\n') SKIP(17);
-      if (lookahead == '\r') SKIP(2);
+      if (lookahead == '\n') ADVANCE(286);
       END_STATE();
     case 4:
-      if (lookahead == '\n') SKIP(14);
+      if (lookahead == '\n') SKIP(16);
       END_STATE();
     case 5:
-      if (lookahead == '\n') SKIP(14);
+      if (lookahead == '\n') SKIP(16);
       if (lookahead == '\r') SKIP(4);
       END_STATE();
     case 6:
-      if (lookahead == '\n') SKIP(16);
+      if (lookahead == '\n') SKIP(19);
       END_STATE();
     case 7:
-      if (lookahead == '\n') SKIP(16);
+      if (lookahead == '\n') SKIP(19);
       if (lookahead == '\r') SKIP(6);
       END_STATE();
     case 8:
-      if (lookahead == '\n') SKIP(19);
+      if (lookahead == '\n') SKIP(18);
       END_STATE();
     case 9:
-      if (lookahead == '\n') SKIP(19);
+      if (lookahead == '\n') SKIP(18);
       if (lookahead == '\r') SKIP(8);
       END_STATE();
     case 10:
-      if (lookahead == '\n') SKIP(20);
+      if (lookahead == '\n') SKIP(22);
       END_STATE();
     case 11:
-      if (lookahead == '\n') SKIP(20);
+      if (lookahead == '\n') SKIP(22);
       if (lookahead == '\r') SKIP(10);
       END_STATE();
     case 12:
-      if (lookahead == '\n') SKIP(21);
-      if (lookahead == '#') ADVANCE(104);
-      if (lookahead == '\\') ADVANCE(266);
-      if (lookahead == 0x200b ||
-          lookahead == 0x2060 ||
-          lookahead == 0xfeff) ADVANCE(267);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(12);
-      if (lookahead != 0) ADVANCE(268);
+      if (lookahead == '\n') SKIP(23);
       END_STATE();
     case 13:
-      if (lookahead == '\n') SKIP(21);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(78);
-      if (lookahead != 0) ADVANCE(268);
+      if (lookahead == '\n') SKIP(23);
+      if (lookahead == '\r') SKIP(12);
       END_STATE();
     case 14:
-      ADVANCE_MAP(
-        '#', 106,
-        '$', 219,
-        '(', 231,
-        ')', 232,
-        '*', 229,
-        '+', 230,
-        ':', 216,
-        '<', 225,
-        '[', 227,
-      );
-      if (lookahead == '\\') SKIP(5);
-      if (lookahead == ']') ADVANCE(228);
-      if (lookahead == '^') ADVANCE(218);
-      if (lookahead == '{') ADVANCE(221);
-      if (lookahead == '|') ADVANCE(217);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ' ||
-          lookahead == 0x200b ||
+      if (lookahead == '\n') SKIP(24);
+      if (lookahead == '#') ADVANCE(110);
+      if (lookahead == '\\') ADVANCE(280);
+      if (lookahead == 0x200b ||
           lookahead == 0x2060 ||
-          lookahead == 0xfeff) SKIP(14);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_1, 476, lookahead)) ADVANCE(220);
+          lookahead == 0xfeff) ADVANCE(281);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(14);
+      if (lookahead != 0) ADVANCE(282);
       END_STATE();
     case 15:
-      ADVANCE_MAP(
-        '#', 106,
-        '%', 243,
-        '(', 251,
-        ')', 232,
-        '*', 229,
-        '+', 230,
-        ',', 252,
-        '-', 209,
-        '/', 242,
-        ':', 216,
-        '=', 241,
-        '>', 226,
-      );
-      if (lookahead == '\\') SKIP(7);
-      if (lookahead == 'o') ADVANCE(67);
-      if (lookahead == '}') ADVANCE(223);
+      if (lookahead == '\n') SKIP(24);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ' ||
-          lookahead == 0x200b ||
-          lookahead == 0x2060 ||
-          lookahead == 0xfeff) SKIP(16);
+          lookahead == ' ') ADVANCE(84);
+      if (lookahead != 0) ADVANCE(282);
       END_STATE();
     case 16:
       ADVANCE_MAP(
-        '#', 106,
-        '%', 243,
-        ')', 232,
-        '*', 229,
-        '+', 230,
-        ',', 252,
-        '-', 209,
-        '/', 242,
-        ':', 216,
-        '=', 241,
-        '>', 226,
+        '#', 112,
+        '$', 228,
+        '(', 240,
+        ')', 241,
+        '*', 238,
+        '+', 239,
+        ':', 225,
+        '<', 234,
+        '[', 236,
       );
-      if (lookahead == '\\') SKIP(7);
-      if (lookahead == 'o') ADVANCE(67);
-      if (lookahead == '}') ADVANCE(223);
+      if (lookahead == '\\') SKIP(5);
+      if (lookahead == ']') ADVANCE(237);
+      if (lookahead == '^') ADVANCE(227);
+      if (lookahead == '{') ADVANCE(230);
+      if (lookahead == '|') ADVANCE(226);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ' ||
           lookahead == 0x200b ||
           lookahead == 0x2060 ||
           lookahead == 0xfeff) SKIP(16);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_1, 476, lookahead)) ADVANCE(229);
       END_STATE();
     case 17:
-      if (lookahead == '#') ADVANCE(106);
-      if (lookahead == '(') ADVANCE(231);
-      if (lookahead == ')') ADVANCE(232);
-      if (lookahead == ',') ADVANCE(252);
-      if (lookahead == '-') ADVANCE(209);
-      if (lookahead == '.') ADVANCE(80);
-      if (lookahead == '0') ADVANCE(255);
-      if (lookahead == '\\') SKIP(3);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'k') ADVANCE(140);
-      if (lookahead == 's') ADVANCE(151);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ' ||
-          lookahead == 0x200b ||
-          lookahead == 0x2060 ||
-          lookahead == 0xfeff) SKIP(17);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(256);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
-      END_STATE();
-    case 18:
       ADVANCE_MAP(
-        '#', 106,
-        '(', 231,
-        '-', 209,
-        '.', 80,
-        '0', 255,
-        '\\', 273,
-        '_', 253,
-        'k', 140,
-        's', 151,
-        '{', 222,
-        '}', 224,
+        '#', 112,
+        '%', 257,
+        '(', 265,
+        ')', 241,
+        '*', 238,
+        '+', 239,
+        ',', 266,
+        '-', 218,
+        '/', 256,
+        ':', 225,
+        '=', 255,
+        '>', 235,
       );
+      if (lookahead == '\\') SKIP(9);
+      if (lookahead == 'i') ADVANCE(65);
+      if (lookahead == 'o') ADVANCE(72);
+      if (lookahead == '}') ADVANCE(232);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ' ||
           lookahead == 0x200b ||
           lookahead == 0x2060 ||
           lookahead == 0xfeff) SKIP(18);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(256);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+      END_STATE();
+    case 18:
+      ADVANCE_MAP(
+        '#', 112,
+        '%', 257,
+        ')', 241,
+        '*', 238,
+        '+', 239,
+        ',', 266,
+        '-', 218,
+        '/', 256,
+        ':', 225,
+        '=', 255,
+        '>', 235,
+      );
+      if (lookahead == '\\') SKIP(9);
+      if (lookahead == 'i') ADVANCE(65);
+      if (lookahead == 'o') ADVANCE(72);
+      if (lookahead == '}') ADVANCE(232);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ' ||
+          lookahead == 0x200b ||
+          lookahead == 0x2060 ||
+          lookahead == 0xfeff) SKIP(18);
       END_STATE();
     case 19:
-      if (lookahead == '#') ADVANCE(106);
-      if (lookahead == '-') ADVANCE(209);
-      if (lookahead == '\\') SKIP(9);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'a') ADVANCE(154);
-      if (lookahead == 'n') ADVANCE(157);
+      if (lookahead == '#') ADVANCE(112);
+      if (lookahead == '(') ADVANCE(240);
+      if (lookahead == ')') ADVANCE(241);
+      if (lookahead == ',') ADVANCE(266);
+      if (lookahead == '-') ADVANCE(218);
+      if (lookahead == '.') ADVANCE(86);
+      if (lookahead == '0') ADVANCE(269);
+      if (lookahead == '\\') SKIP(7);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'k') ADVANCE(146);
+      if (lookahead == 's') ADVANCE(158);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ' ||
           lookahead == 0x200b ||
           lookahead == 0x2060 ||
           lookahead == 0xfeff) SKIP(19);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(270);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 20:
-      if (lookahead == '#') ADVANCE(106);
-      if (lookahead == '\\') SKIP(11);
-      if (lookahead == '_') ADVANCE(253);
+      if (lookahead == '#') ADVANCE(112);
+      if (lookahead == '(') ADVANCE(240);
+      if (lookahead == '-') ADVANCE(218);
+      if (lookahead == '.') ADVANCE(86);
+      if (lookahead == '0') ADVANCE(269);
+      if (lookahead == '\\') SKIP(2);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'f') ADVANCE(164);
+      if (lookahead == 'i') ADVANCE(152);
+      if (lookahead == 'k') ADVANCE(146);
+      if (lookahead == 's') ADVANCE(158);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ' ||
           lookahead == 0x200b ||
           lookahead == 0x2060 ||
           lookahead == 0xfeff) SKIP(20);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(270);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 21:
-      if (lookahead == '#') ADVANCE(104);
-      if (lookahead == '\\') ADVANCE(266);
-      if (lookahead == 0x200b ||
-          lookahead == 0x2060 ||
-          lookahead == 0xfeff) ADVANCE(267);
+      ADVANCE_MAP(
+        '#', 112,
+        '(', 240,
+        '-', 218,
+        '.', 86,
+        '0', 269,
+        '\\', 287,
+        '_', 267,
+        'k', 146,
+        's', 158,
+        '{', 231,
+        '}', 233,
+      );
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(21);
-      if (lookahead != 0) ADVANCE(268);
+          lookahead == ' ' ||
+          lookahead == 0x200b ||
+          lookahead == 0x2060 ||
+          lookahead == 0xfeff) SKIP(21);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(270);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 22:
-      if (lookahead == '(') ADVANCE(233);
+      if (lookahead == '#') ADVANCE(112);
+      if (lookahead == '-') ADVANCE(218);
+      if (lookahead == '\\') SKIP(11);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'a') ADVANCE(161);
+      if (lookahead == 'n') ADVANCE(165);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ' ||
+          lookahead == 0x200b ||
+          lookahead == 0x2060 ||
+          lookahead == 0xfeff) SKIP(22);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 23:
-      if (lookahead == '(') ADVANCE(245);
+      if (lookahead == '#') ADVANCE(112);
+      if (lookahead == '\\') SKIP(13);
+      if (lookahead == '_') ADVANCE(267);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ' ||
+          lookahead == 0x200b ||
+          lookahead == 0x2060 ||
+          lookahead == 0xfeff) SKIP(23);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 24:
-      if (lookahead == '(') ADVANCE(32);
+      if (lookahead == '#') ADVANCE(110);
+      if (lookahead == '\\') ADVANCE(280);
+      if (lookahead == 0x200b ||
+          lookahead == 0x2060 ||
+          lookahead == 0xfeff) ADVANCE(281);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(24);
+      if (lookahead != 0) ADVANCE(282);
       END_STATE();
     case 25:
-      if (lookahead == '(') ADVANCE(235);
+      if (lookahead == '(') ADVANCE(242);
       END_STATE();
     case 26:
-      if (lookahead == '(') ADVANCE(234);
+      if (lookahead == '(') ADVANCE(259);
       END_STATE();
     case 27:
-      if (lookahead == '(') ADVANCE(237);
+      if (lookahead == '(') ADVANCE(35);
       END_STATE();
     case 28:
-      if (lookahead == '(') ADVANCE(246);
+      if (lookahead == '(') ADVANCE(244);
       END_STATE();
     case 29:
-      if (lookahead == '(') ADVANCE(238);
+      if (lookahead == '(') ADVANCE(243);
       END_STATE();
     case 30:
-      if (lookahead == '(') ADVANCE(236);
+      if (lookahead == '(') ADVANCE(246);
       END_STATE();
     case 31:
-      if (lookahead == '(') ADVANCE(33);
+      if (lookahead == '(') ADVANCE(260);
       END_STATE();
     case 32:
-      if (lookahead == ')') ADVANCE(240);
+      if (lookahead == '(') ADVANCE(247);
       END_STATE();
     case 33:
-      if (lookahead == ')') ADVANCE(239);
+      if (lookahead == '(') ADVANCE(245);
       END_STATE();
     case 34:
-      if (lookahead == '_') ADVANCE(77);
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(258);
+      if (lookahead == '(') ADVANCE(36);
       END_STATE();
     case 35:
-      if (lookahead == '_') ADVANCE(79);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(259);
+      if (lookahead == ')') ADVANCE(249);
       END_STATE();
     case 36:
-      if (lookahead == '_') ADVANCE(84);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(260);
+      if (lookahead == ')') ADVANCE(248);
       END_STATE();
     case 37:
-      if (lookahead == 'a') ADVANCE(59);
+      if (lookahead == '_') ADVANCE(83);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(272);
       END_STATE();
     case 38:
-      if (lookahead == 'a') ADVANCE(55);
+      if (lookahead == '_') ADVANCE(85);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(273);
       END_STATE();
     case 39:
-      if (lookahead == 'a') ADVANCE(69);
+      if (lookahead == '_') ADVANCE(90);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(274);
       END_STATE();
     case 40:
-      if (lookahead == 'a') ADVANCE(45);
+      if (lookahead == 'a') ADVANCE(63);
       END_STATE();
     case 41:
-      if (lookahead == 'a') ADVANCE(43);
+      if (lookahead == 'a') ADVANCE(59);
       END_STATE();
     case 42:
-      if (lookahead == 'c') ADVANCE(58);
+      if (lookahead == 'a') ADVANCE(48);
       END_STATE();
     case 43:
-      if (lookahead == 'c') ADVANCE(50);
+      if (lookahead == 'a') ADVANCE(46);
+      if (lookahead == 'o') ADVANCE(73);
       END_STATE();
     case 44:
-      if (lookahead == 'd') ADVANCE(210);
+      if (lookahead == 'a') ADVANCE(75);
       END_STATE();
     case 45:
-      if (lookahead == 'd') ADVANCE(30);
+      if (lookahead == 'c') ADVANCE(62);
       END_STATE();
     case 46:
-      if (lookahead == 'e') ADVANCE(42);
+      if (lookahead == 'c') ADVANCE(53);
       END_STATE();
     case 47:
-      if (lookahead == 'e') ADVANCE(75);
+      if (lookahead == 'd') ADVANCE(219);
       END_STATE();
     case 48:
-      if (lookahead == 'e') ADVANCE(73);
-      if (lookahead == 'l') ADVANCE(51);
+      if (lookahead == 'd') ADVANCE(33);
       END_STATE();
     case 49:
-      if (lookahead == 'e') ADVANCE(65);
+      if (lookahead == 'e') ADVANCE(45);
       END_STATE();
     case 50:
-      if (lookahead == 'e') ADVANCE(26);
+      if (lookahead == 'e') ADVANCE(81);
       END_STATE();
     case 51:
-      if (lookahead == 'e') ADVANCE(53);
+      if (lookahead == 'e') ADVANCE(79);
+      if (lookahead == 'l') ADVANCE(54);
       END_STATE();
     case 52:
-      if (lookahead == 'e') ADVANCE(27);
+      if (lookahead == 'e') ADVANCE(70);
       END_STATE();
     case 53:
-      if (lookahead == 'e') ADVANCE(66);
+      if (lookahead == 'e') ADVANCE(29);
       END_STATE();
     case 54:
-      if (lookahead == 'g') ADVANCE(70);
+      if (lookahead == 'e') ADVANCE(56);
       END_STATE();
     case 55:
-      if (lookahead == 'g') ADVANCE(24);
+      if (lookahead == 'e') ADVANCE(30);
       END_STATE();
     case 56:
-      if (lookahead == 'i') ADVANCE(71);
-      if (lookahead == 't') ADVANCE(213);
+      if (lookahead == 'e') ADVANCE(71);
       END_STATE();
     case 57:
-      if (lookahead == 'i') ADVANCE(61);
+      if (lookahead == 'f') ADVANCE(250);
+      if (lookahead == 'n') ADVANCE(254);
       END_STATE();
     case 58:
-      if (lookahead == 'k') ADVANCE(25);
+      if (lookahead == 'g') ADVANCE(76);
       END_STATE();
     case 59:
-      if (lookahead == 'm') ADVANCE(49);
+      if (lookahead == 'g') ADVANCE(27);
       END_STATE();
     case 60:
-      if (lookahead == 'n') ADVANCE(44);
-      if (lookahead == 'p') ADVANCE(64);
+      if (lookahead == 'i') ADVANCE(77);
+      if (lookahead == 't') ADVANCE(222);
       END_STATE();
     case 61:
-      if (lookahead == 'n') ADVANCE(54);
+      if (lookahead == 'i') ADVANCE(66);
       END_STATE();
     case 62:
-      if (lookahead == 'o') ADVANCE(56);
+      if (lookahead == 'k') ADVANCE(28);
       END_STATE();
     case 63:
-      if (lookahead == 'o') ADVANCE(74);
+      if (lookahead == 'm') ADVANCE(52);
       END_STATE();
     case 64:
-      if (lookahead == 'p') ADVANCE(22);
+      if (lookahead == 'n') ADVANCE(47);
+      if (lookahead == 'p') ADVANCE(69);
       END_STATE();
     case 65:
-      if (lookahead == 'p') ADVANCE(40);
+      if (lookahead == 'n') ADVANCE(254);
       END_STATE();
     case 66:
-      if (lookahead == 'p') ADVANCE(28);
+      if (lookahead == 'n') ADVANCE(58);
       END_STATE();
     case 67:
-      if (lookahead == 'r') ADVANCE(244);
+      if (lookahead == 'o') ADVANCE(60);
       END_STATE();
     case 68:
-      if (lookahead == 'r') ADVANCE(63);
+      if (lookahead == 'o') ADVANCE(80);
       END_STATE();
     case 69:
-      if (lookahead == 'r') ADVANCE(68);
+      if (lookahead == 'p') ADVANCE(25);
       END_STATE();
     case 70:
-      if (lookahead == 's') ADVANCE(31);
+      if (lookahead == 'p') ADVANCE(42);
       END_STATE();
     case 71:
-      if (lookahead == 's') ADVANCE(52);
+      if (lookahead == 'p') ADVANCE(31);
       END_STATE();
     case 72:
-      if (lookahead == 't') ADVANCE(57);
+      if (lookahead == 'r') ADVANCE(258);
       END_STATE();
     case 73:
-      if (lookahead == 't') ADVANCE(72);
+      if (lookahead == 'r') ADVANCE(252);
       END_STATE();
     case 74:
-      if (lookahead == 't') ADVANCE(29);
+      if (lookahead == 'r') ADVANCE(68);
       END_STATE();
     case 75:
-      if (lookahead == 'y') ADVANCE(23);
+      if (lookahead == 'r') ADVANCE(74);
       END_STATE();
     case 76:
-      if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(81);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(263);
+      if (lookahead == 's') ADVANCE(34);
       END_STATE();
     case 77:
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(258);
+      if (lookahead == 's') ADVANCE(55);
       END_STATE();
     case 78:
-      if (lookahead == '\t' ||
-          (0x0b <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(78);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(268);
+      if (lookahead == 't') ADVANCE(61);
       END_STATE();
     case 79:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(259);
+      if (lookahead == 't') ADVANCE(78);
       END_STATE();
     case 80:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(262);
+      if (lookahead == 't') ADVANCE(32);
       END_STATE();
     case 81:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(263);
+      if (lookahead == 'y') ADVANCE(26);
       END_STATE();
     case 82:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(271);
+      if (lookahead == '+' ||
+          lookahead == '-') ADVANCE(87);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(277);
       END_STATE();
     case 83:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(82);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(272);
       END_STATE();
     case 84:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(260);
+      if (lookahead == '\t' ||
+          (0x0b <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(84);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(282);
       END_STATE();
     case 85:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(271);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(273);
       END_STATE();
     case 86:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(85);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(276);
       END_STATE();
     case 87:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(86);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(277);
       END_STATE();
     case 88:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(87);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(285);
       END_STATE();
     case 89:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(88);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(88);
       END_STATE();
     case 90:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(89);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(274);
       END_STATE();
     case 91:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(90);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(285);
       END_STATE();
     case 92:
       if (('0' <= lookahead && lookahead <= '9') ||
@@ -1793,1442 +1877,1525 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(91);
       END_STATE();
     case 93:
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(253);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(92);
       END_STATE();
     case 94:
-      if (eof) ADVANCE(103);
-      if (lookahead == '\n') SKIP(100);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(93);
       END_STATE();
     case 95:
-      if (eof) ADVANCE(103);
-      if (lookahead == '\n') SKIP(100);
-      if (lookahead == '\r') SKIP(94);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(94);
       END_STATE();
     case 96:
-      if (eof) ADVANCE(103);
-      if (lookahead == '\n') SKIP(101);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(95);
       END_STATE();
     case 97:
-      if (eof) ADVANCE(103);
-      if (lookahead == '\n') SKIP(101);
-      if (lookahead == '\r') SKIP(96);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(96);
       END_STATE();
     case 98:
-      if (eof) ADVANCE(103);
-      if (lookahead == '\n') SKIP(102);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(97);
       END_STATE();
     case 99:
-      if (eof) ADVANCE(103);
-      if (lookahead == '\n') SKIP(102);
-      if (lookahead == '\r') SKIP(98);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(267);
       END_STATE();
     case 100:
-      if (eof) ADVANCE(103);
-      ADVANCE_MAP(
-        '#', 106,
-        '$', 219,
-        '%', 243,
-        '(', 231,
-        ')', 232,
-        '*', 229,
-        '+', 230,
-        ',', 252,
-        '-', 209,
-        '.', 80,
-        '/', 242,
-        '0', 255,
-        ':', 216,
-        '<', 225,
-        '=', 241,
-        '>', 226,
-        '[', 227,
-      );
-      if (lookahead == '\\') SKIP(95);
-      if (lookahead == ']') ADVANCE(228);
-      if (lookahead == '^') ADVANCE(218);
-      if (lookahead == 'a') ADVANCE(60);
-      if (lookahead == 'd') ADVANCE(46);
-      if (lookahead == 'f') ADVANCE(41);
-      if (lookahead == 'g') ADVANCE(37);
-      if (lookahead == 'k') ADVANCE(47);
-      if (lookahead == 'n') ADVANCE(62);
-      if (lookahead == 'o') ADVANCE(67);
-      if (lookahead == 'p') ADVANCE(39);
-      if (lookahead == 's') ADVANCE(48);
-      if (lookahead == 't') ADVANCE(38);
-      if (lookahead == '{') ADVANCE(222);
-      if (lookahead == '|') ADVANCE(217);
-      if (lookahead == '}') ADVANCE(224);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ' ||
-          lookahead == 0x200b ||
-          lookahead == 0x2060 ||
-          lookahead == 0xfeff) SKIP(100);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(256);
+      if (eof) ADVANCE(109);
+      if (lookahead == '\n') SKIP(106);
       END_STATE();
     case 101:
-      if (eof) ADVANCE(103);
-      if (lookahead == '#') ADVANCE(106);
-      if (lookahead == '(') ADVANCE(231);
-      if (lookahead == '-') ADVANCE(209);
-      if (lookahead == '<') ADVANCE(225);
-      if (lookahead == '[') ADVANCE(227);
-      if (lookahead == '\\') SKIP(97);
-      if (lookahead == '^') ADVANCE(218);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'a') ADVANCE(153);
-      if (lookahead == 'd') ADVANCE(137);
-      if (lookahead == 'f') ADVANCE(131);
-      if (lookahead == 'g') ADVANCE(127);
-      if (lookahead == 'k') ADVANCE(138);
-      if (lookahead == 'n') ADVANCE(156);
-      if (lookahead == 'p') ADVANCE(128);
-      if (lookahead == 's') ADVANCE(139);
-      if (lookahead == 't') ADVANCE(129);
-      if (lookahead == '{') ADVANCE(221);
-      if (lookahead == '}') ADVANCE(223);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ' ||
-          lookahead == 0x200b ||
-          lookahead == 0x2060 ||
-          lookahead == 0xfeff) SKIP(101);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_1, 476, lookahead)) ADVANCE(220);
+      if (eof) ADVANCE(109);
+      if (lookahead == '\n') SKIP(106);
+      if (lookahead == '\r') SKIP(100);
       END_STATE();
     case 102:
-      if (eof) ADVANCE(103);
-      if (lookahead == '#') ADVANCE(106);
-      if (lookahead == '(') ADVANCE(231);
-      if (lookahead == '<') ADVANCE(225);
-      if (lookahead == '[') ADVANCE(227);
-      if (lookahead == '\\') SKIP(99);
-      if (lookahead == '^') ADVANCE(218);
-      if (lookahead == 'a') ADVANCE(198);
-      if (lookahead == 'd') ADVANCE(182);
-      if (lookahead == 'f') ADVANCE(178);
-      if (lookahead == 'g') ADVANCE(174);
-      if (lookahead == 'k') ADVANCE(183);
-      if (lookahead == 'n') ADVANCE(195);
-      if (lookahead == 'p') ADVANCE(175);
-      if (lookahead == 's') ADVANCE(184);
-      if (lookahead == 't') ADVANCE(176);
-      if (lookahead == '{') ADVANCE(221);
+      if (eof) ADVANCE(109);
+      if (lookahead == '\n') SKIP(107);
+      END_STATE();
+    case 103:
+      if (eof) ADVANCE(109);
+      if (lookahead == '\n') SKIP(107);
+      if (lookahead == '\r') SKIP(102);
+      END_STATE();
+    case 104:
+      if (eof) ADVANCE(109);
+      if (lookahead == '\n') SKIP(108);
+      END_STATE();
+    case 105:
+      if (eof) ADVANCE(109);
+      if (lookahead == '\n') SKIP(108);
+      if (lookahead == '\r') SKIP(104);
+      END_STATE();
+    case 106:
+      if (eof) ADVANCE(109);
+      ADVANCE_MAP(
+        '#', 112,
+        '$', 228,
+        '%', 257,
+        '(', 240,
+        ')', 241,
+        '*', 238,
+        '+', 239,
+        ',', 266,
+        '-', 218,
+        '.', 86,
+        '/', 256,
+        '0', 269,
+        ':', 225,
+        '<', 234,
+        '=', 255,
+        '>', 235,
+        '[', 236,
+      );
+      if (lookahead == '\\') SKIP(101);
+      if (lookahead == ']') ADVANCE(237);
+      if (lookahead == '^') ADVANCE(227);
+      if (lookahead == 'a') ADVANCE(64);
+      if (lookahead == 'd') ADVANCE(49);
+      if (lookahead == 'f') ADVANCE(43);
+      if (lookahead == 'g') ADVANCE(40);
+      if (lookahead == 'i') ADVANCE(57);
+      if (lookahead == 'k') ADVANCE(50);
+      if (lookahead == 'n') ADVANCE(67);
+      if (lookahead == 'o') ADVANCE(72);
+      if (lookahead == 'p') ADVANCE(44);
+      if (lookahead == 's') ADVANCE(51);
+      if (lookahead == 't') ADVANCE(41);
+      if (lookahead == '{') ADVANCE(231);
+      if (lookahead == '|') ADVANCE(226);
+      if (lookahead == '}') ADVANCE(233);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ' ||
           lookahead == 0x200b ||
           lookahead == 0x2060 ||
-          lookahead == 0xfeff) SKIP(102);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_1, 476, lookahead)) ADVANCE(220);
+          lookahead == 0xfeff) SKIP(106);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(270);
       END_STATE();
-    case 103:
+    case 107:
+      if (eof) ADVANCE(109);
+      if (lookahead == '#') ADVANCE(112);
+      if (lookahead == '(') ADVANCE(240);
+      if (lookahead == '-') ADVANCE(218);
+      if (lookahead == '<') ADVANCE(234);
+      if (lookahead == '[') ADVANCE(236);
+      if (lookahead == '\\') SKIP(103);
+      if (lookahead == '^') ADVANCE(227);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'a') ADVANCE(160);
+      if (lookahead == 'd') ADVANCE(143);
+      if (lookahead == 'f') ADVANCE(137);
+      if (lookahead == 'g') ADVANCE(133);
+      if (lookahead == 'k') ADVANCE(144);
+      if (lookahead == 'n') ADVANCE(163);
+      if (lookahead == 'p') ADVANCE(134);
+      if (lookahead == 's') ADVANCE(145);
+      if (lookahead == 't') ADVANCE(135);
+      if (lookahead == '{') ADVANCE(230);
+      if (lookahead == '}') ADVANCE(232);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ' ||
+          lookahead == 0x200b ||
+          lookahead == 0x2060 ||
+          lookahead == 0xfeff) SKIP(107);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_1, 476, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 108:
+      if (eof) ADVANCE(109);
+      if (lookahead == '#') ADVANCE(112);
+      if (lookahead == '(') ADVANCE(240);
+      if (lookahead == '<') ADVANCE(234);
+      if (lookahead == '[') ADVANCE(236);
+      if (lookahead == '\\') SKIP(105);
+      if (lookahead == '^') ADVANCE(227);
+      if (lookahead == 'a') ADVANCE(207);
+      if (lookahead == 'd') ADVANCE(191);
+      if (lookahead == 'f') ADVANCE(187);
+      if (lookahead == 'g') ADVANCE(183);
+      if (lookahead == 'k') ADVANCE(192);
+      if (lookahead == 'n') ADVANCE(204);
+      if (lookahead == 'p') ADVANCE(184);
+      if (lookahead == 's') ADVANCE(193);
+      if (lookahead == 't') ADVANCE(185);
+      if (lookahead == '{') ADVANCE(230);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ' ||
+          lookahead == 0x200b ||
+          lookahead == 0x2060 ||
+          lookahead == 0xfeff) SKIP(108);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_1, 476, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 109:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 104:
+    case 110:
       ACCEPT_TOKEN(sym_comment);
-      if (lookahead == '\r') ADVANCE(78);
+      if (lookahead == '\r') ADVANCE(84);
       if (lookahead == '\t' ||
           lookahead == 0x0b ||
           lookahead == '\f' ||
-          lookahead == ' ') ADVANCE(104);
+          lookahead == ' ') ADVANCE(110);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(104);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(110);
       END_STATE();
-    case 105:
+    case 111:
       ACCEPT_TOKEN(sym_comment);
-      if (lookahead == ')') ADVANCE(106);
+      if (lookahead == ')') ADVANCE(112);
       if (lookahead == '\n' ||
-          lookahead == '\r') ADVANCE(250);
-      if (lookahead != 0) ADVANCE(105);
+          lookahead == '\r') ADVANCE(264);
+      if (lookahead != 0) ADVANCE(111);
       END_STATE();
-    case 106:
+    case 112:
       ACCEPT_TOKEN(sym_comment);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(106);
-      END_STATE();
-    case 107:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(233);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 108:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(233);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 109:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(245);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 110:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(245);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
-      END_STATE();
-    case 111:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(245);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 112:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(32);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          lookahead != '\r') ADVANCE(112);
       END_STATE();
     case 113:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(32);
+      if (lookahead == '(') ADVANCE(242);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 114:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(235);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
+      if (lookahead == '(') ADVANCE(242);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 115:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(235);
+      if (lookahead == '(') ADVANCE(259);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 116:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(234);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
+      if (lookahead == '(') ADVANCE(259);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 117:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(234);
+      if (lookahead == '(') ADVANCE(259);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 118:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(237);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
+      if (lookahead == '(') ADVANCE(35);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 119:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(237);
+      if (lookahead == '(') ADVANCE(35);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 120:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(246);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
+      if (lookahead == '(') ADVANCE(244);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 121:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(238);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
+      if (lookahead == '(') ADVANCE(244);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 122:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(238);
+      if (lookahead == '(') ADVANCE(243);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 123:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(236);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
+      if (lookahead == '(') ADVANCE(243);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 124:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(236);
+      if (lookahead == '(') ADVANCE(246);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 125:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(33);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
+      if (lookahead == '(') ADVANCE(246);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 126:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '(') ADVANCE(33);
+      if (lookahead == '(') ADVANCE(260);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 127:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'a') ADVANCE(152);
+      if (lookahead == '(') ADVANCE(247);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 128:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'a') ADVANCE(163);
+      if (lookahead == '(') ADVANCE(247);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 129:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'a') ADVANCE(147);
+      if (lookahead == '(') ADVANCE(245);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 130:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'a') ADVANCE(136);
+      if (lookahead == '(') ADVANCE(245);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 131:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'a') ADVANCE(133);
+      if (lookahead == '(') ADVANCE(36);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 132:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'c') ADVANCE(150);
+      if (lookahead == '(') ADVANCE(36);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 133:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'c') ADVANCE(144);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'a') ADVANCE(159);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 134:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'd') ADVANCE(211);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'a') ADVANCE(172);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 135:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'd') ADVANCE(212);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'a') ADVANCE(154);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 136:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'd') ADVANCE(123);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'a') ADVANCE(142);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 137:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'e') ADVANCE(132);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'a') ADVANCE(139);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 138:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'e') ADVANCE(171);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'c') ADVANCE(157);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 139:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'e') ADVANCE(168);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'c') ADVANCE(150);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 140:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'e') ADVANCE(170);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'd') ADVANCE(220);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 141:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'e') ADVANCE(160);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'd') ADVANCE(221);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 142:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'e') ADVANCE(161);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'd') ADVANCE(129);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 143:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'e') ADVANCE(141);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'e') ADVANCE(138);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 144:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'e') ADVANCE(116);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'e') ADVANCE(180);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 145:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'e') ADVANCE(118);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'e') ADVANCE(177);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 146:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'g') ADVANCE(164);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'e') ADVANCE(179);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 147:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'g') ADVANCE(112);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'e') ADVANCE(168);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 148:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'i') ADVANCE(165);
-      if (lookahead == 't') ADVANCE(214);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'e') ADVANCE(169);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 149:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'i') ADVANCE(155);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'e') ADVANCE(147);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 150:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'k') ADVANCE(114);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'e') ADVANCE(122);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 151:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'l') ADVANCE(143);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'e') ADVANCE(124);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 152:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'm') ADVANCE(142);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'f') ADVANCE(251);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 153:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'n') ADVANCE(134);
-      if (lookahead == 'p') ADVANCE(159);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'g') ADVANCE(173);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 154:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'n') ADVANCE(135);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'g') ADVANCE(118);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 155:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'n') ADVANCE(146);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'i') ADVANCE(174);
+      if (lookahead == 't') ADVANCE(223);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 156:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'o') ADVANCE(148);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'i') ADVANCE(162);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 157:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'o') ADVANCE(167);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'k') ADVANCE(120);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 158:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'o') ADVANCE(169);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'l') ADVANCE(149);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 159:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'p') ADVANCE(107);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'm') ADVANCE(148);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 160:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'p') ADVANCE(120);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'n') ADVANCE(140);
+      if (lookahead == 'p') ADVANCE(167);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 161:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'p') ADVANCE(130);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'n') ADVANCE(141);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 162:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'r') ADVANCE(158);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'n') ADVANCE(153);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 163:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'r') ADVANCE(162);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'o') ADVANCE(155);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 164:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 's') ADVANCE(125);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'o') ADVANCE(170);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 165:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 's') ADVANCE(145);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'o') ADVANCE(176);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 166:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 't') ADVANCE(149);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'o') ADVANCE(178);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 167:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 't') ADVANCE(215);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'p') ADVANCE(113);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 168:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 't') ADVANCE(166);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'p') ADVANCE(126);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 169:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 't') ADVANCE(121);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'p') ADVANCE(136);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 170:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'y') ADVANCE(110);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'r') ADVANCE(253);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 171:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
-      if (lookahead == 'y') ADVANCE(109);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'r') ADVANCE(166);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 172:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'r') ADVANCE(171);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 173:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 's') ADVANCE(131);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 174:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'a') ADVANCE(193);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 's') ADVANCE(151);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 175:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'a') ADVANCE(201);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 't') ADVANCE(156);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 176:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 't') ADVANCE(224);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
+      END_STATE();
+    case 177:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 't') ADVANCE(175);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 178:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 't') ADVANCE(127);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 179:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'y') ADVANCE(116);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
+      END_STATE();
+    case 180:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (lookahead == 'y') ADVANCE(115);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 181:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 182:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
+      END_STATE();
+    case 183:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'a') ADVANCE(202);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 184:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'a') ADVANCE(210);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 185:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'a') ADVANCE(198);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 186:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'a') ADVANCE(190);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 187:
       ACCEPT_TOKEN(sym__simple_identifier);
       if (lookahead == 'a') ADVANCE(189);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 177:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'a') ADVANCE(181);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 178:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'a') ADVANCE(180);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 179:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'c') ADVANCE(192);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 180:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'c') ADVANCE(186);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 181:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'd') ADVANCE(124);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 182:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'e') ADVANCE(179);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 183:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'e') ADVANCE(207);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 184:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'e') ADVANCE(205);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 185:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'e') ADVANCE(199);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 186:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'e') ADVANCE(117);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 187:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'e') ADVANCE(119);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 188:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'g') ADVANCE(202);
+      if (lookahead == 'c') ADVANCE(201);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 189:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'g') ADVANCE(113);
+      if (lookahead == 'c') ADVANCE(195);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 190:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'd') ADVANCE(130);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 191:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'e') ADVANCE(188);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 192:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'e') ADVANCE(216);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 193:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'e') ADVANCE(214);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 194:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'e') ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 195:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'e') ADVANCE(123);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 196:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'e') ADVANCE(125);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 197:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'g') ADVANCE(211);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 198:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'g') ADVANCE(119);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 199:
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'i') ADVANCE(212);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
+      END_STATE();
+    case 200:
       ACCEPT_TOKEN(sym__simple_identifier);
       if (lookahead == 'i') ADVANCE(203);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 191:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'i') ADVANCE(194);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 192:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'k') ADVANCE(115);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 193:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'm') ADVANCE(185);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 194:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'n') ADVANCE(188);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 195:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'o') ADVANCE(190);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 196:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'o') ADVANCE(206);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 197:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'p') ADVANCE(108);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 198:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'p') ADVANCE(197);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 199:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'p') ADVANCE(177);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
-      END_STATE();
-    case 200:
-      ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'r') ADVANCE(196);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 201:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'r') ADVANCE(200);
+      if (lookahead == 'k') ADVANCE(121);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 202:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 's') ADVANCE(126);
+      if (lookahead == 'm') ADVANCE(194);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 203:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 's') ADVANCE(187);
+      if (lookahead == 'n') ADVANCE(197);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 204:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 't') ADVANCE(191);
+      if (lookahead == 'o') ADVANCE(199);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 205:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 't') ADVANCE(204);
+      if (lookahead == 'o') ADVANCE(215);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 206:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 't') ADVANCE(122);
+      if (lookahead == 'p') ADVANCE(114);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 207:
       ACCEPT_TOKEN(sym__simple_identifier);
-      if (lookahead == 'y') ADVANCE(111);
+      if (lookahead == 'p') ADVANCE(206);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 208:
       ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'p') ADVANCE(186);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 209:
-      ACCEPT_TOKEN(anon_sym_DASH);
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'r') ADVANCE(205);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 210:
-      ACCEPT_TOKEN(anon_sym_and);
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'r') ADVANCE(209);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 211:
-      ACCEPT_TOKEN(anon_sym_and);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 's') ADVANCE(132);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 212:
-      ACCEPT_TOKEN(anon_sym_and);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 's') ADVANCE(196);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 213:
-      ACCEPT_TOKEN(anon_sym_not);
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 't') ADVANCE(200);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 214:
-      ACCEPT_TOKEN(anon_sym_not);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 't') ADVANCE(213);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(172);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 215:
-      ACCEPT_TOKEN(anon_sym_not);
-      if (lookahead == '.') ADVANCE(93);
-      if (lookahead == '_') ADVANCE(253);
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 't') ADVANCE(128);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(173);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 216:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (lookahead == 'y') ADVANCE(117);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 217:
-      ACCEPT_TOKEN(anon_sym_PIPE);
+      ACCEPT_TOKEN(sym__simple_identifier);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(217);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 218:
-      ACCEPT_TOKEN(sym_start_anchor);
+      ACCEPT_TOKEN(anon_sym_DASH);
       END_STATE();
     case 219:
-      ACCEPT_TOKEN(sym_end_anchor);
+      ACCEPT_TOKEN(anon_sym_and);
       END_STATE();
     case 220:
-      ACCEPT_TOKEN(aux_sym_word_token1);
-      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(220);
+      ACCEPT_TOKEN(anon_sym_and);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 221:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
+      ACCEPT_TOKEN(anon_sym_and);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 222:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '{') ADVANCE(269);
+      ACCEPT_TOKEN(anon_sym_not);
       END_STATE();
     case 223:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
+      ACCEPT_TOKEN(anon_sym_not);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(181);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 224:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
-      if (lookahead == '}') ADVANCE(270);
+      ACCEPT_TOKEN(anon_sym_not);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
       END_STATE();
     case 225:
-      ACCEPT_TOKEN(anon_sym_LT);
+      ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
     case 226:
-      ACCEPT_TOKEN(anon_sym_GT);
+      ACCEPT_TOKEN(anon_sym_PIPE);
       END_STATE();
     case 227:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
+      ACCEPT_TOKEN(sym_start_anchor);
       END_STATE();
     case 228:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
+      ACCEPT_TOKEN(sym_end_anchor);
       END_STATE();
     case 229:
-      ACCEPT_TOKEN(anon_sym_STAR);
+      ACCEPT_TOKEN(aux_sym_word_token1);
+      if (set_contains(aux_sym_word_token1_character_set_2, 478, lookahead)) ADVANCE(229);
       END_STATE();
     case 230:
-      ACCEPT_TOKEN(anon_sym_PLUS);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
     case 231:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '{') ADVANCE(283);
       END_STATE();
     case 232:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
+      ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
     case 233:
-      ACCEPT_TOKEN(anon_sym_app_LPAREN);
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      if (lookahead == '}') ADVANCE(284);
       END_STATE();
     case 234:
-      ACCEPT_TOKEN(anon_sym_face_LPAREN);
+      ACCEPT_TOKEN(anon_sym_LT);
       END_STATE();
     case 235:
-      ACCEPT_TOKEN(anon_sym_deck_LPAREN);
+      ACCEPT_TOKEN(anon_sym_GT);
       END_STATE();
     case 236:
-      ACCEPT_TOKEN(anon_sym_gamepad_LPAREN);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
     case 237:
-      ACCEPT_TOKEN(anon_sym_noise_LPAREN);
+      ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
     case 238:
-      ACCEPT_TOKEN(anon_sym_parrot_LPAREN);
+      ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
     case 239:
-      ACCEPT_TOKEN(sym_settings_binding);
+      ACCEPT_TOKEN(anon_sym_PLUS);
       END_STATE();
     case 240:
-      ACCEPT_TOKEN(sym_tag_binding);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
     case 241:
-      ACCEPT_TOKEN(anon_sym_EQ);
+      ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
     case 242:
-      ACCEPT_TOKEN(anon_sym_SLASH);
+      ACCEPT_TOKEN(anon_sym_app_LPAREN);
       END_STATE();
     case 243:
-      ACCEPT_TOKEN(anon_sym_PERCENT);
+      ACCEPT_TOKEN(anon_sym_face_LPAREN);
       END_STATE();
     case 244:
-      ACCEPT_TOKEN(anon_sym_or);
+      ACCEPT_TOKEN(anon_sym_deck_LPAREN);
       END_STATE();
     case 245:
-      ACCEPT_TOKEN(anon_sym_key_LPAREN);
+      ACCEPT_TOKEN(anon_sym_gamepad_LPAREN);
       END_STATE();
     case 246:
-      ACCEPT_TOKEN(anon_sym_sleep_LPAREN);
+      ACCEPT_TOKEN(anon_sym_noise_LPAREN);
       END_STATE();
     case 247:
-      ACCEPT_TOKEN(aux_sym__implicit_string_argument_token1);
-      if (lookahead == '\n') ADVANCE(249);
-      if (lookahead == '\r') ADVANCE(248);
-      if (lookahead != 0 &&
-          lookahead != ')') ADVANCE(250);
+      ACCEPT_TOKEN(anon_sym_parrot_LPAREN);
       END_STATE();
     case 248:
-      ACCEPT_TOKEN(aux_sym__implicit_string_argument_token1);
-      if (lookahead == '\n') ADVANCE(249);
-      if (lookahead != 0 &&
-          lookahead != ')') ADVANCE(250);
+      ACCEPT_TOKEN(sym_settings_binding);
       END_STATE();
     case 249:
+      ACCEPT_TOKEN(sym_tag_binding);
+      END_STATE();
+    case 250:
+      ACCEPT_TOKEN(anon_sym_if);
+      END_STATE();
+    case 251:
+      ACCEPT_TOKEN(anon_sym_if);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
+      END_STATE();
+    case 252:
+      ACCEPT_TOKEN(anon_sym_for);
+      END_STATE();
+    case 253:
+      ACCEPT_TOKEN(anon_sym_for);
+      if (lookahead == '.') ADVANCE(99);
+      if (lookahead == '_') ADVANCE(267);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(182);
+      END_STATE();
+    case 254:
+      ACCEPT_TOKEN(anon_sym_in);
+      END_STATE();
+    case 255:
+      ACCEPT_TOKEN(anon_sym_EQ);
+      END_STATE();
+    case 256:
+      ACCEPT_TOKEN(anon_sym_SLASH);
+      END_STATE();
+    case 257:
+      ACCEPT_TOKEN(anon_sym_PERCENT);
+      END_STATE();
+    case 258:
+      ACCEPT_TOKEN(anon_sym_or);
+      END_STATE();
+    case 259:
+      ACCEPT_TOKEN(anon_sym_key_LPAREN);
+      END_STATE();
+    case 260:
+      ACCEPT_TOKEN(anon_sym_sleep_LPAREN);
+      END_STATE();
+    case 261:
       ACCEPT_TOKEN(aux_sym__implicit_string_argument_token1);
-      if (lookahead == '#') ADVANCE(105);
-      if (lookahead == '\\') ADVANCE(247);
+      if (lookahead == '\n') ADVANCE(263);
+      if (lookahead == '\r') ADVANCE(262);
+      if (lookahead != 0 &&
+          lookahead != ')') ADVANCE(264);
+      END_STATE();
+    case 262:
+      ACCEPT_TOKEN(aux_sym__implicit_string_argument_token1);
+      if (lookahead == '\n') ADVANCE(263);
+      if (lookahead != 0 &&
+          lookahead != ')') ADVANCE(264);
+      END_STATE();
+    case 263:
+      ACCEPT_TOKEN(aux_sym__implicit_string_argument_token1);
+      if (lookahead == '#') ADVANCE(111);
+      if (lookahead == '\\') ADVANCE(261);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ' ||
           lookahead == 0x200b ||
           lookahead == 0x2060 ||
-          lookahead == 0xfeff) ADVANCE(249);
+          lookahead == 0xfeff) ADVANCE(263);
       if (lookahead != 0 &&
-          lookahead != ')') ADVANCE(250);
+          lookahead != ')') ADVANCE(264);
       END_STATE();
-    case 250:
+    case 264:
       ACCEPT_TOKEN(aux_sym__implicit_string_argument_token1);
       if (lookahead != 0 &&
-          lookahead != ')') ADVANCE(250);
+          lookahead != ')') ADVANCE(264);
       END_STATE();
-    case 251:
+    case 265:
       ACCEPT_TOKEN(anon_sym_LPAREN2);
       END_STATE();
-    case 252:
+    case 266:
       ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
-    case 253:
+    case 267:
       ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '.') ADVANCE(93);
+      if (lookahead == '.') ADVANCE(99);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(253);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(267);
       END_STATE();
-    case 254:
+    case 268:
       ACCEPT_TOKEN(sym_integer);
       END_STATE();
-    case 255:
-      ACCEPT_TOKEN(sym_integer);
-      ADVANCE_MAP(
-        '.', 264,
-        '_', 257,
-        'B', 34,
-        'b', 34,
-        'E', 76,
-        'e', 76,
-        'O', 35,
-        'o', 35,
-        'X', 36,
-        'x', 36,
-        'J', 254,
-        'L', 254,
-        'j', 254,
-        'l', 254,
-      );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(256);
-      END_STATE();
-    case 256:
+    case 269:
       ACCEPT_TOKEN(sym_integer);
       ADVANCE_MAP(
-        '.', 264,
-        '_', 257,
-        'E', 76,
-        'e', 76,
-        'J', 254,
-        'L', 254,
-        'j', 254,
-        'l', 254,
+        '.', 278,
+        '_', 271,
+        'B', 37,
+        'b', 37,
+        'E', 82,
+        'e', 82,
+        'O', 38,
+        'o', 38,
+        'X', 39,
+        'x', 39,
+        'J', 268,
+        'L', 268,
+        'j', 268,
+        'l', 268,
       );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(256);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(270);
       END_STATE();
-    case 257:
+    case 270:
       ACCEPT_TOKEN(sym_integer);
-      if (lookahead == '.') ADVANCE(264);
+      ADVANCE_MAP(
+        '.', 278,
+        '_', 271,
+        'E', 82,
+        'e', 82,
+        'J', 268,
+        'L', 268,
+        'j', 268,
+        'l', 268,
+      );
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(270);
+      END_STATE();
+    case 271:
+      ACCEPT_TOKEN(sym_integer);
+      if (lookahead == '.') ADVANCE(278);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(76);
+          lookahead == 'e') ADVANCE(82);
       if (lookahead == 'J' ||
           lookahead == 'L' ||
           lookahead == 'j' ||
-          lookahead == 'l') ADVANCE(254);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(256);
+          lookahead == 'l') ADVANCE(268);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(270);
       END_STATE();
-    case 258:
+    case 272:
       ACCEPT_TOKEN(sym_integer);
-      if (lookahead == '_') ADVANCE(77);
+      if (lookahead == '_') ADVANCE(83);
       if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(254);
+          lookahead == 'l') ADVANCE(268);
       if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(258);
+          lookahead == '1') ADVANCE(272);
       END_STATE();
-    case 259:
+    case 273:
       ACCEPT_TOKEN(sym_integer);
-      if (lookahead == '_') ADVANCE(79);
+      if (lookahead == '_') ADVANCE(85);
       if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(254);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(259);
+          lookahead == 'l') ADVANCE(268);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(273);
       END_STATE();
-    case 260:
+    case 274:
       ACCEPT_TOKEN(sym_integer);
-      if (lookahead == '_') ADVANCE(84);
+      if (lookahead == '_') ADVANCE(90);
       if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(254);
+          lookahead == 'l') ADVANCE(268);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(260);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(274);
       END_STATE();
-    case 261:
+    case 275:
       ACCEPT_TOKEN(sym_float);
       END_STATE();
-    case 262:
+    case 276:
       ACCEPT_TOKEN(sym_float);
-      if (lookahead == '_') ADVANCE(264);
+      if (lookahead == '_') ADVANCE(278);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(76);
+          lookahead == 'e') ADVANCE(82);
       if (lookahead == 'J' ||
           lookahead == 'L' ||
           lookahead == 'j' ||
-          lookahead == 'l') ADVANCE(261);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(262);
+          lookahead == 'l') ADVANCE(275);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(276);
       END_STATE();
-    case 263:
+    case 277:
       ACCEPT_TOKEN(sym_float);
-      if (lookahead == '_') ADVANCE(265);
+      if (lookahead == '_') ADVANCE(279);
       if (lookahead == 'J' ||
           lookahead == 'L' ||
           lookahead == 'j' ||
-          lookahead == 'l') ADVANCE(261);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(263);
+          lookahead == 'l') ADVANCE(275);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(277);
       END_STATE();
-    case 264:
+    case 278:
       ACCEPT_TOKEN(sym_float);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(76);
+          lookahead == 'e') ADVANCE(82);
       if (lookahead == 'J' ||
           lookahead == 'L' ||
           lookahead == 'j' ||
-          lookahead == 'l') ADVANCE(261);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(262);
+          lookahead == 'l') ADVANCE(275);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(276);
       END_STATE();
-    case 265:
+    case 279:
       ACCEPT_TOKEN(sym_float);
       if (lookahead == 'J' ||
           lookahead == 'L' ||
           lookahead == 'j' ||
-          lookahead == 'l') ADVANCE(261);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(263);
+          lookahead == 'l') ADVANCE(275);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(277);
       END_STATE();
-    case 266:
+    case 280:
       ACCEPT_TOKEN(sym_implicit_string);
-      if (lookahead == '\r') ADVANCE(13);
+      if (lookahead == '\r') ADVANCE(15);
       if (lookahead == '\t' ||
           lookahead == 0x0b ||
           lookahead == '\f' ||
-          lookahead == ' ') ADVANCE(78);
+          lookahead == ' ') ADVANCE(84);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(268);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(282);
       END_STATE();
-    case 267:
+    case 281:
       ACCEPT_TOKEN(sym_implicit_string);
-      if (lookahead == '#') ADVANCE(104);
-      if (lookahead == '\\') ADVANCE(266);
+      if (lookahead == '#') ADVANCE(110);
+      if (lookahead == '\\') ADVANCE(280);
       if (lookahead == 0x200b ||
           lookahead == 0x2060 ||
-          lookahead == 0xfeff) ADVANCE(267);
+          lookahead == 0xfeff) ADVANCE(281);
       if (lookahead == '\t' ||
           (0x0b <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(12);
+          lookahead == ' ') ADVANCE(14);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(268);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(282);
       END_STATE();
-    case 268:
+    case 282:
       ACCEPT_TOKEN(sym_implicit_string);
       if (lookahead == '\t' ||
           (0x0b <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(78);
+          lookahead == ' ') ADVANCE(84);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(268);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(282);
       END_STATE();
-    case 269:
+    case 283:
       ACCEPT_TOKEN(anon_sym_LBRACE_LBRACE);
       END_STATE();
-    case 270:
+    case 284:
       ACCEPT_TOKEN(anon_sym_RBRACE_RBRACE);
       END_STATE();
-    case 271:
+    case 285:
       ACCEPT_TOKEN(sym_string_escape_sequence);
       END_STATE();
-    case 272:
+    case 286:
       ACCEPT_TOKEN(sym_string_escape_sequence);
-      if (lookahead == '\\') ADVANCE(273);
+      if (lookahead == '\\') ADVANCE(287);
       END_STATE();
-    case 273:
+    case 287:
       ACCEPT_TOKEN(sym__not_escapesequence);
       ADVANCE_MAP(
-        '\n', 272,
-        '\r', 1,
-        'U', 92,
-        'u', 88,
-        'x', 86,
-        '"', 271,
-        '\'', 271,
-        '\\', 271,
-        'a', 271,
-        'b', 271,
-        'f', 271,
-        'n', 271,
-        'r', 271,
-        't', 271,
-        'v', 271,
+        '\n', 286,
+        '\r', 3,
+        'U', 98,
+        'u', 94,
+        'x', 92,
+        '"', 285,
+        '\'', 285,
+        '\\', 285,
+        'a', 285,
+        'b', 285,
+        'f', 285,
+        'n', 285,
+        'r', 285,
+        't', 285,
+        'v', 285,
       );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(83);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(89);
       END_STATE();
     default:
       return false;
@@ -3237,199 +3404,199 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0, .external_lex_state = 1},
-  [1] = {.lex_state = 101, .external_lex_state = 2},
-  [2] = {.lex_state = 102, .external_lex_state = 2},
-  [3] = {.lex_state = 102, .external_lex_state = 2},
-  [4] = {.lex_state = 102, .external_lex_state = 2},
-  [5] = {.lex_state = 18, .external_lex_state = 3},
-  [6] = {.lex_state = 17, .external_lex_state = 4},
-  [7] = {.lex_state = 17, .external_lex_state = 5},
-  [8] = {.lex_state = 17, .external_lex_state = 5},
-  [9] = {.lex_state = 17, .external_lex_state = 4},
-  [10] = {.lex_state = 17, .external_lex_state = 5},
-  [11] = {.lex_state = 17, .external_lex_state = 4},
-  [12] = {.lex_state = 17, .external_lex_state = 5},
-  [13] = {.lex_state = 17, .external_lex_state = 5},
-  [14] = {.lex_state = 17, .external_lex_state = 5},
-  [15] = {.lex_state = 17, .external_lex_state = 5},
-  [16] = {.lex_state = 17, .external_lex_state = 5},
-  [17] = {.lex_state = 17, .external_lex_state = 5},
-  [18] = {.lex_state = 14, .external_lex_state = 2},
-  [19] = {.lex_state = 17, .external_lex_state = 6},
-  [20] = {.lex_state = 17, .external_lex_state = 6},
-  [21] = {.lex_state = 14, .external_lex_state = 2},
-  [22] = {.lex_state = 17, .external_lex_state = 6},
-  [23] = {.lex_state = 17, .external_lex_state = 6},
-  [24] = {.lex_state = 17, .external_lex_state = 6},
-  [25] = {.lex_state = 14, .external_lex_state = 2},
-  [26] = {.lex_state = 14, .external_lex_state = 2},
-  [27] = {.lex_state = 14, .external_lex_state = 2},
-  [28] = {.lex_state = 17, .external_lex_state = 6},
-  [29] = {.lex_state = 17, .external_lex_state = 6},
-  [30] = {.lex_state = 17, .external_lex_state = 6},
-  [31] = {.lex_state = 17, .external_lex_state = 6},
-  [32] = {.lex_state = 17, .external_lex_state = 6},
-  [33] = {.lex_state = 17, .external_lex_state = 6},
-  [34] = {.lex_state = 17, .external_lex_state = 6},
-  [35] = {.lex_state = 17, .external_lex_state = 6},
-  [36] = {.lex_state = 17, .external_lex_state = 6},
-  [37] = {.lex_state = 17, .external_lex_state = 6},
-  [38] = {.lex_state = 17, .external_lex_state = 6},
-  [39] = {.lex_state = 17, .external_lex_state = 6},
-  [40] = {.lex_state = 17, .external_lex_state = 6},
-  [41] = {.lex_state = 17, .external_lex_state = 6},
-  [42] = {.lex_state = 14, .external_lex_state = 2},
-  [43] = {.lex_state = 102, .external_lex_state = 2},
-  [44] = {.lex_state = 102, .external_lex_state = 2},
-  [45] = {.lex_state = 102, .external_lex_state = 2},
-  [46] = {.lex_state = 102, .external_lex_state = 2},
-  [47] = {.lex_state = 102, .external_lex_state = 2},
-  [48] = {.lex_state = 102, .external_lex_state = 2},
-  [49] = {.lex_state = 102, .external_lex_state = 2},
-  [50] = {.lex_state = 102, .external_lex_state = 2},
-  [51] = {.lex_state = 102, .external_lex_state = 2},
-  [52] = {.lex_state = 102, .external_lex_state = 2},
-  [53] = {.lex_state = 102, .external_lex_state = 2},
-  [54] = {.lex_state = 102, .external_lex_state = 2},
-  [55] = {.lex_state = 102, .external_lex_state = 2},
-  [56] = {.lex_state = 102, .external_lex_state = 2},
-  [57] = {.lex_state = 102, .external_lex_state = 2},
-  [58] = {.lex_state = 102, .external_lex_state = 2},
-  [59] = {.lex_state = 102, .external_lex_state = 2},
-  [60] = {.lex_state = 102, .external_lex_state = 2},
-  [61] = {.lex_state = 102, .external_lex_state = 2},
-  [62] = {.lex_state = 102, .external_lex_state = 2},
-  [63] = {.lex_state = 14, .external_lex_state = 2},
-  [64] = {.lex_state = 14, .external_lex_state = 2},
-  [65] = {.lex_state = 14, .external_lex_state = 2},
-  [66] = {.lex_state = 14, .external_lex_state = 2},
-  [67] = {.lex_state = 14, .external_lex_state = 2},
-  [68] = {.lex_state = 14, .external_lex_state = 2},
-  [69] = {.lex_state = 14, .external_lex_state = 2},
-  [70] = {.lex_state = 14, .external_lex_state = 2},
-  [71] = {.lex_state = 14, .external_lex_state = 2},
-  [72] = {.lex_state = 18, .external_lex_state = 7},
-  [73] = {.lex_state = 18, .external_lex_state = 7},
-  [74] = {.lex_state = 18, .external_lex_state = 7},
-  [75] = {.lex_state = 18, .external_lex_state = 7},
-  [76] = {.lex_state = 15, .external_lex_state = 2},
-  [77] = {.lex_state = 18, .external_lex_state = 7},
-  [78] = {.lex_state = 14, .external_lex_state = 2},
-  [79] = {.lex_state = 19, .external_lex_state = 2},
-  [80] = {.lex_state = 15, .external_lex_state = 2},
-  [81] = {.lex_state = 19, .external_lex_state = 2},
-  [82] = {.lex_state = 15, .external_lex_state = 8},
-  [83] = {.lex_state = 15, .external_lex_state = 2},
-  [84] = {.lex_state = 17, .external_lex_state = 4},
-  [85] = {.lex_state = 15, .external_lex_state = 8},
-  [86] = {.lex_state = 17, .external_lex_state = 4},
-  [87] = {.lex_state = 17, .external_lex_state = 4},
-  [88] = {.lex_state = 15, .external_lex_state = 2},
-  [89] = {.lex_state = 15, .external_lex_state = 2},
-  [90] = {.lex_state = 15, .external_lex_state = 2},
-  [91] = {.lex_state = 0, .external_lex_state = 2},
-  [92] = {.lex_state = 15, .external_lex_state = 2},
-  [93] = {.lex_state = 15, .external_lex_state = 2},
-  [94] = {.lex_state = 15, .external_lex_state = 2},
-  [95] = {.lex_state = 15, .external_lex_state = 2},
-  [96] = {.lex_state = 15, .external_lex_state = 2},
-  [97] = {.lex_state = 15, .external_lex_state = 2},
-  [98] = {.lex_state = 15, .external_lex_state = 2},
-  [99] = {.lex_state = 15, .external_lex_state = 2},
-  [100] = {.lex_state = 15, .external_lex_state = 2},
-  [101] = {.lex_state = 15, .external_lex_state = 2},
-  [102] = {.lex_state = 15, .external_lex_state = 2},
-  [103] = {.lex_state = 15, .external_lex_state = 8},
-  [104] = {.lex_state = 0, .external_lex_state = 2},
-  [105] = {.lex_state = 15, .external_lex_state = 8},
-  [106] = {.lex_state = 18, .external_lex_state = 7},
-  [107] = {.lex_state = 18, .external_lex_state = 7},
-  [108] = {.lex_state = 0, .external_lex_state = 2},
-  [109] = {.lex_state = 18, .external_lex_state = 7},
-  [110] = {.lex_state = 0, .external_lex_state = 8},
-  [111] = {.lex_state = 0, .external_lex_state = 8},
-  [112] = {.lex_state = 0, .external_lex_state = 8},
-  [113] = {.lex_state = 0, .external_lex_state = 2},
-  [114] = {.lex_state = 0, .external_lex_state = 8},
-  [115] = {.lex_state = 0, .external_lex_state = 8},
-  [116] = {.lex_state = 0, .external_lex_state = 8},
-  [117] = {.lex_state = 19, .external_lex_state = 2},
-  [118] = {.lex_state = 15, .external_lex_state = 2},
-  [119] = {.lex_state = 0, .external_lex_state = 8},
-  [120] = {.lex_state = 0, .external_lex_state = 8},
-  [121] = {.lex_state = 0, .external_lex_state = 8},
-  [122] = {.lex_state = 0, .external_lex_state = 8},
+  [1] = {.lex_state = 107, .external_lex_state = 2},
+  [2] = {.lex_state = 108, .external_lex_state = 2},
+  [3] = {.lex_state = 108, .external_lex_state = 2},
+  [4] = {.lex_state = 108, .external_lex_state = 2},
+  [5] = {.lex_state = 20, .external_lex_state = 3},
+  [6] = {.lex_state = 20, .external_lex_state = 4},
+  [7] = {.lex_state = 20, .external_lex_state = 4},
+  [8] = {.lex_state = 20, .external_lex_state = 4},
+  [9] = {.lex_state = 20, .external_lex_state = 4},
+  [10] = {.lex_state = 20, .external_lex_state = 4},
+  [11] = {.lex_state = 20, .external_lex_state = 4},
+  [12] = {.lex_state = 20, .external_lex_state = 4},
+  [13] = {.lex_state = 20, .external_lex_state = 4},
+  [14] = {.lex_state = 20, .external_lex_state = 3},
+  [15] = {.lex_state = 20, .external_lex_state = 3},
+  [16] = {.lex_state = 20, .external_lex_state = 4},
+  [17] = {.lex_state = 21, .external_lex_state = 5},
+  [18] = {.lex_state = 20, .external_lex_state = 6},
+  [19] = {.lex_state = 20, .external_lex_state = 6},
+  [20] = {.lex_state = 20, .external_lex_state = 6},
+  [21] = {.lex_state = 20, .external_lex_state = 6},
+  [22] = {.lex_state = 16, .external_lex_state = 2},
+  [23] = {.lex_state = 19, .external_lex_state = 6},
+  [24] = {.lex_state = 19, .external_lex_state = 6},
+  [25] = {.lex_state = 16, .external_lex_state = 2},
+  [26] = {.lex_state = 16, .external_lex_state = 2},
+  [27] = {.lex_state = 19, .external_lex_state = 6},
+  [28] = {.lex_state = 19, .external_lex_state = 6},
+  [29] = {.lex_state = 16, .external_lex_state = 2},
+  [30] = {.lex_state = 16, .external_lex_state = 2},
+  [31] = {.lex_state = 19, .external_lex_state = 6},
+  [32] = {.lex_state = 19, .external_lex_state = 6},
+  [33] = {.lex_state = 19, .external_lex_state = 6},
+  [34] = {.lex_state = 19, .external_lex_state = 6},
+  [35] = {.lex_state = 19, .external_lex_state = 6},
+  [36] = {.lex_state = 19, .external_lex_state = 6},
+  [37] = {.lex_state = 19, .external_lex_state = 6},
+  [38] = {.lex_state = 19, .external_lex_state = 6},
+  [39] = {.lex_state = 19, .external_lex_state = 6},
+  [40] = {.lex_state = 19, .external_lex_state = 6},
+  [41] = {.lex_state = 19, .external_lex_state = 6},
+  [42] = {.lex_state = 19, .external_lex_state = 6},
+  [43] = {.lex_state = 19, .external_lex_state = 6},
+  [44] = {.lex_state = 19, .external_lex_state = 6},
+  [45] = {.lex_state = 19, .external_lex_state = 6},
+  [46] = {.lex_state = 19, .external_lex_state = 6},
+  [47] = {.lex_state = 19, .external_lex_state = 6},
+  [48] = {.lex_state = 19, .external_lex_state = 6},
+  [49] = {.lex_state = 19, .external_lex_state = 6},
+  [50] = {.lex_state = 16, .external_lex_state = 2},
+  [51] = {.lex_state = 108, .external_lex_state = 2},
+  [52] = {.lex_state = 108, .external_lex_state = 2},
+  [53] = {.lex_state = 108, .external_lex_state = 2},
+  [54] = {.lex_state = 108, .external_lex_state = 2},
+  [55] = {.lex_state = 108, .external_lex_state = 2},
+  [56] = {.lex_state = 108, .external_lex_state = 2},
+  [57] = {.lex_state = 108, .external_lex_state = 2},
+  [58] = {.lex_state = 108, .external_lex_state = 2},
+  [59] = {.lex_state = 108, .external_lex_state = 2},
+  [60] = {.lex_state = 108, .external_lex_state = 2},
+  [61] = {.lex_state = 108, .external_lex_state = 2},
+  [62] = {.lex_state = 108, .external_lex_state = 2},
+  [63] = {.lex_state = 108, .external_lex_state = 2},
+  [64] = {.lex_state = 108, .external_lex_state = 2},
+  [65] = {.lex_state = 108, .external_lex_state = 2},
+  [66] = {.lex_state = 108, .external_lex_state = 2},
+  [67] = {.lex_state = 108, .external_lex_state = 2},
+  [68] = {.lex_state = 108, .external_lex_state = 2},
+  [69] = {.lex_state = 108, .external_lex_state = 2},
+  [70] = {.lex_state = 108, .external_lex_state = 2},
+  [71] = {.lex_state = 108, .external_lex_state = 2},
+  [72] = {.lex_state = 108, .external_lex_state = 2},
+  [73] = {.lex_state = 16, .external_lex_state = 2},
+  [74] = {.lex_state = 16, .external_lex_state = 2},
+  [75] = {.lex_state = 16, .external_lex_state = 2},
+  [76] = {.lex_state = 16, .external_lex_state = 2},
+  [77] = {.lex_state = 17, .external_lex_state = 2},
+  [78] = {.lex_state = 16, .external_lex_state = 2},
+  [79] = {.lex_state = 16, .external_lex_state = 2},
+  [80] = {.lex_state = 16, .external_lex_state = 2},
+  [81] = {.lex_state = 16, .external_lex_state = 2},
+  [82] = {.lex_state = 16, .external_lex_state = 2},
+  [83] = {.lex_state = 20, .external_lex_state = 3},
+  [84] = {.lex_state = 21, .external_lex_state = 7},
+  [85] = {.lex_state = 21, .external_lex_state = 7},
+  [86] = {.lex_state = 21, .external_lex_state = 7},
+  [87] = {.lex_state = 21, .external_lex_state = 7},
+  [88] = {.lex_state = 21, .external_lex_state = 7},
+  [89] = {.lex_state = 20, .external_lex_state = 3},
+  [90] = {.lex_state = 17, .external_lex_state = 2},
+  [91] = {.lex_state = 20, .external_lex_state = 3},
+  [92] = {.lex_state = 20, .external_lex_state = 3},
+  [93] = {.lex_state = 20, .external_lex_state = 3},
+  [94] = {.lex_state = 16, .external_lex_state = 2},
+  [95] = {.lex_state = 22, .external_lex_state = 2},
+  [96] = {.lex_state = 17, .external_lex_state = 2},
+  [97] = {.lex_state = 17, .external_lex_state = 8},
+  [98] = {.lex_state = 17, .external_lex_state = 2},
+  [99] = {.lex_state = 17, .external_lex_state = 2},
+  [100] = {.lex_state = 17, .external_lex_state = 2},
+  [101] = {.lex_state = 17, .external_lex_state = 2},
+  [102] = {.lex_state = 22, .external_lex_state = 2},
+  [103] = {.lex_state = 17, .external_lex_state = 8},
+  [104] = {.lex_state = 17, .external_lex_state = 2},
+  [105] = {.lex_state = 17, .external_lex_state = 2},
+  [106] = {.lex_state = 17, .external_lex_state = 2},
+  [107] = {.lex_state = 17, .external_lex_state = 2},
+  [108] = {.lex_state = 17, .external_lex_state = 2},
+  [109] = {.lex_state = 17, .external_lex_state = 2},
+  [110] = {.lex_state = 17, .external_lex_state = 2},
+  [111] = {.lex_state = 17, .external_lex_state = 2},
+  [112] = {.lex_state = 17, .external_lex_state = 2},
+  [113] = {.lex_state = 17, .external_lex_state = 2},
+  [114] = {.lex_state = 0, .external_lex_state = 2},
+  [115] = {.lex_state = 0, .external_lex_state = 2},
+  [116] = {.lex_state = 17, .external_lex_state = 8},
+  [117] = {.lex_state = 17, .external_lex_state = 8},
+  [118] = {.lex_state = 21, .external_lex_state = 7},
+  [119] = {.lex_state = 21, .external_lex_state = 7},
+  [120] = {.lex_state = 0, .external_lex_state = 2},
+  [121] = {.lex_state = 21, .external_lex_state = 7},
+  [122] = {.lex_state = 0, .external_lex_state = 2},
   [123] = {.lex_state = 0, .external_lex_state = 8},
   [124] = {.lex_state = 0, .external_lex_state = 8},
   [125] = {.lex_state = 0, .external_lex_state = 8},
-  [126] = {.lex_state = 0, .external_lex_state = 2},
+  [126] = {.lex_state = 0, .external_lex_state = 8},
   [127] = {.lex_state = 0, .external_lex_state = 8},
   [128] = {.lex_state = 0, .external_lex_state = 8},
-  [129] = {.lex_state = 0, .external_lex_state = 8},
-  [130] = {.lex_state = 0, .external_lex_state = 8},
+  [129] = {.lex_state = 0, .external_lex_state = 2},
+  [130] = {.lex_state = 0, .external_lex_state = 2},
   [131] = {.lex_state = 0, .external_lex_state = 8},
-  [132] = {.lex_state = 0, .external_lex_state = 8},
-  [133] = {.lex_state = 19, .external_lex_state = 2},
-  [134] = {.lex_state = 0, .external_lex_state = 2},
-  [135] = {.lex_state = 19, .external_lex_state = 2},
-  [136] = {.lex_state = 0, .external_lex_state = 2},
-  [137] = {.lex_state = 19, .external_lex_state = 2},
-  [138] = {.lex_state = 0, .external_lex_state = 2},
-  [139] = {.lex_state = 0, .external_lex_state = 2},
-  [140] = {.lex_state = 0, .external_lex_state = 2},
-  [141] = {.lex_state = 0, .external_lex_state = 2},
-  [142] = {.lex_state = 0, .external_lex_state = 2},
-  [143] = {.lex_state = 19, .external_lex_state = 2},
-  [144] = {.lex_state = 0, .external_lex_state = 2},
-  [145] = {.lex_state = 0, .external_lex_state = 8},
+  [132] = {.lex_state = 0, .external_lex_state = 2},
+  [133] = {.lex_state = 0, .external_lex_state = 2},
+  [134] = {.lex_state = 22, .external_lex_state = 2},
+  [135] = {.lex_state = 0, .external_lex_state = 8},
+  [136] = {.lex_state = 0, .external_lex_state = 8},
+  [137] = {.lex_state = 0, .external_lex_state = 8},
+  [138] = {.lex_state = 0, .external_lex_state = 8},
+  [139] = {.lex_state = 0, .external_lex_state = 8},
+  [140] = {.lex_state = 0, .external_lex_state = 8},
+  [141] = {.lex_state = 17, .external_lex_state = 2},
+  [142] = {.lex_state = 0, .external_lex_state = 8},
+  [143] = {.lex_state = 0, .external_lex_state = 8},
+  [144] = {.lex_state = 0, .external_lex_state = 8},
+  [145] = {.lex_state = 0, .external_lex_state = 2},
   [146] = {.lex_state = 0, .external_lex_state = 8},
-  [147] = {.lex_state = 20, .external_lex_state = 2},
-  [148] = {.lex_state = 20, .external_lex_state = 2},
-  [149] = {.lex_state = 20, .external_lex_state = 2},
+  [147] = {.lex_state = 0, .external_lex_state = 8},
+  [148] = {.lex_state = 0, .external_lex_state = 8},
+  [149] = {.lex_state = 22, .external_lex_state = 2},
   [150] = {.lex_state = 0, .external_lex_state = 2},
-  [151] = {.lex_state = 0, .external_lex_state = 8},
+  [151] = {.lex_state = 0, .external_lex_state = 2},
   [152] = {.lex_state = 0, .external_lex_state = 2},
-  [153] = {.lex_state = 0, .external_lex_state = 2},
-  [154] = {.lex_state = 249, .external_lex_state = 2},
-  [155] = {.lex_state = 249, .external_lex_state = 2},
-  [156] = {.lex_state = 249, .external_lex_state = 2},
-  [157] = {.lex_state = 249, .external_lex_state = 2},
-  [158] = {.lex_state = 249, .external_lex_state = 2},
-  [159] = {.lex_state = 249, .external_lex_state = 2},
-  [160] = {.lex_state = 249, .external_lex_state = 2},
-  [161] = {.lex_state = 249, .external_lex_state = 2},
-  [162] = {.lex_state = 249, .external_lex_state = 2},
-  [163] = {.lex_state = 249, .external_lex_state = 2},
-  [164] = {.lex_state = 0, .external_lex_state = 2},
-  [165] = {.lex_state = 0, .external_lex_state = 2},
+  [153] = {.lex_state = 22, .external_lex_state = 2},
+  [154] = {.lex_state = 0, .external_lex_state = 2},
+  [155] = {.lex_state = 22, .external_lex_state = 2},
+  [156] = {.lex_state = 0, .external_lex_state = 2},
+  [157] = {.lex_state = 0, .external_lex_state = 2},
+  [158] = {.lex_state = 22, .external_lex_state = 2},
+  [159] = {.lex_state = 0, .external_lex_state = 2},
+  [160] = {.lex_state = 0, .external_lex_state = 2},
+  [161] = {.lex_state = 0, .external_lex_state = 2},
+  [162] = {.lex_state = 23, .external_lex_state = 2},
+  [163] = {.lex_state = 23, .external_lex_state = 2},
+  [164] = {.lex_state = 23, .external_lex_state = 2},
+  [165] = {.lex_state = 0, .external_lex_state = 8},
   [166] = {.lex_state = 0, .external_lex_state = 2},
-  [167] = {.lex_state = 0, .external_lex_state = 2},
-  [168] = {.lex_state = 0, .external_lex_state = 2},
-  [169] = {.lex_state = 101, .external_lex_state = 2},
-  [170] = {.lex_state = 0, .external_lex_state = 2},
+  [167] = {.lex_state = 0, .external_lex_state = 8},
+  [168] = {.lex_state = 23, .external_lex_state = 2},
+  [169] = {.lex_state = 23, .external_lex_state = 2},
+  [170] = {.lex_state = 0, .external_lex_state = 8},
   [171] = {.lex_state = 0, .external_lex_state = 2},
-  [172] = {.lex_state = 0, .external_lex_state = 2},
-  [173] = {.lex_state = 0, .external_lex_state = 2},
-  [174] = {.lex_state = 0, .external_lex_state = 2},
-  [175] = {.lex_state = 0, .external_lex_state = 2},
-  [176] = {.lex_state = 21, .external_lex_state = 2},
-  [177] = {.lex_state = 0, .external_lex_state = 2},
-  [178] = {.lex_state = 0, .external_lex_state = 2},
-  [179] = {.lex_state = 0, .external_lex_state = 2},
-  [180] = {.lex_state = 0, .external_lex_state = 2},
-  [181] = {.lex_state = 0, .external_lex_state = 2},
-  [182] = {.lex_state = 21, .external_lex_state = 2},
+  [172] = {.lex_state = 263, .external_lex_state = 2},
+  [173] = {.lex_state = 263, .external_lex_state = 2},
+  [174] = {.lex_state = 263, .external_lex_state = 2},
+  [175] = {.lex_state = 263, .external_lex_state = 2},
+  [176] = {.lex_state = 263, .external_lex_state = 2},
+  [177] = {.lex_state = 263, .external_lex_state = 2},
+  [178] = {.lex_state = 263, .external_lex_state = 2},
+  [179] = {.lex_state = 263, .external_lex_state = 2},
+  [180] = {.lex_state = 263, .external_lex_state = 2},
+  [181] = {.lex_state = 263, .external_lex_state = 2},
+  [182] = {.lex_state = 0, .external_lex_state = 2},
   [183] = {.lex_state = 0, .external_lex_state = 2},
   [184] = {.lex_state = 0, .external_lex_state = 2},
   [185] = {.lex_state = 0, .external_lex_state = 2},
   [186] = {.lex_state = 0, .external_lex_state = 2},
-  [187] = {.lex_state = 0, .external_lex_state = 8},
+  [187] = {.lex_state = 0, .external_lex_state = 2},
   [188] = {.lex_state = 0, .external_lex_state = 2},
   [189] = {.lex_state = 0, .external_lex_state = 2},
   [190] = {.lex_state = 0, .external_lex_state = 2},
   [191] = {.lex_state = 0, .external_lex_state = 2},
-  [192] = {.lex_state = 0, .external_lex_state = 2},
-  [193] = {.lex_state = 0, .external_lex_state = 8},
+  [192] = {.lex_state = 24, .external_lex_state = 2},
+  [193] = {.lex_state = 0, .external_lex_state = 2},
   [194] = {.lex_state = 0, .external_lex_state = 2},
   [195] = {.lex_state = 0, .external_lex_state = 2},
   [196] = {.lex_state = 0, .external_lex_state = 2},
@@ -3438,11 +3605,31 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [199] = {.lex_state = 0, .external_lex_state = 2},
   [200] = {.lex_state = 0, .external_lex_state = 2},
   [201] = {.lex_state = 0, .external_lex_state = 2},
-  [202] = {.lex_state = 0, .external_lex_state = 8},
+  [202] = {.lex_state = 0, .external_lex_state = 2},
   [203] = {.lex_state = 0, .external_lex_state = 2},
   [204] = {.lex_state = 0, .external_lex_state = 2},
   [205] = {.lex_state = 0, .external_lex_state = 2},
   [206] = {.lex_state = 0, .external_lex_state = 2},
+  [207] = {.lex_state = 24, .external_lex_state = 2},
+  [208] = {.lex_state = 0, .external_lex_state = 8},
+  [209] = {.lex_state = 0, .external_lex_state = 2},
+  [210] = {.lex_state = 0, .external_lex_state = 2},
+  [211] = {.lex_state = 0, .external_lex_state = 2},
+  [212] = {.lex_state = 0, .external_lex_state = 2},
+  [213] = {.lex_state = 0, .external_lex_state = 2},
+  [214] = {.lex_state = 0, .external_lex_state = 2},
+  [215] = {.lex_state = 0, .external_lex_state = 2},
+  [216] = {.lex_state = 0, .external_lex_state = 8},
+  [217] = {.lex_state = 0, .external_lex_state = 2},
+  [218] = {.lex_state = 0, .external_lex_state = 8},
+  [219] = {.lex_state = 107, .external_lex_state = 2},
+  [220] = {.lex_state = 0, .external_lex_state = 2},
+  [221] = {.lex_state = 0, .external_lex_state = 2},
+  [222] = {.lex_state = 0, .external_lex_state = 2},
+  [223] = {.lex_state = 0, .external_lex_state = 2},
+  [224] = {.lex_state = 0, .external_lex_state = 2},
+  [225] = {.lex_state = 0, .external_lex_state = 2},
+  [226] = {.lex_state = 0, .external_lex_state = 2},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -3474,6 +3661,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_parrot_LPAREN] = ACTIONS(1),
     [sym_settings_binding] = ACTIONS(1),
     [sym_tag_binding] = ACTIONS(1),
+    [anon_sym_if] = ACTIONS(1),
+    [anon_sym_for] = ACTIONS(1),
+    [anon_sym_in] = ACTIONS(1),
     [anon_sym_EQ] = ACTIONS(1),
     [anon_sym_SLASH] = ACTIONS(1),
     [anon_sym_PERCENT] = ACTIONS(1),
@@ -3494,48 +3684,48 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__string_end] = ACTIONS(1),
   },
   [1] = {
-    [sym_source_file] = STATE(186),
+    [sym_source_file] = STATE(191),
     [sym_matches] = STATE(2),
-    [sym_match_modifier] = STATE(117),
-    [sym_match] = STATE(79),
-    [sym_declarations] = STATE(165),
-    [sym_declaration] = STATE(4),
-    [sym_command_declaration] = STATE(44),
-    [sym_app_declaration] = STATE(44),
-    [sym_face_declaration] = STATE(44),
-    [sym_deck_declaration] = STATE(44),
-    [sym_gamepad_declaration] = STATE(44),
-    [sym_noise_declaration] = STATE(44),
-    [sym_parrot_declaration] = STATE(44),
-    [sym_tag_import_declaration] = STATE(44),
-    [sym_key_binding_declaration] = STATE(44),
-    [sym_settings_declaration] = STATE(44),
-    [sym_rule] = STATE(184),
-    [sym__optional_choice] = STATE(183),
-    [sym_choice] = STATE(183),
-    [sym__optional_anchor] = STATE(140),
-    [sym__optional_seq] = STATE(134),
-    [sym_seq] = STATE(134),
-    [sym__primary_rule] = STATE(18),
-    [sym_word] = STATE(18),
-    [sym_list] = STATE(18),
-    [sym_capture] = STATE(18),
-    [sym_optional] = STATE(18),
-    [sym_repeat] = STATE(18),
-    [sym_repeat1] = STATE(18),
-    [sym_parenthesized_rule] = STATE(18),
-    [sym_app_binding] = STATE(180),
-    [sym_face_binding] = STATE(179),
-    [sym_deck_binding] = STATE(178),
-    [sym_gamepad_binding] = STATE(177),
-    [sym_noise_binding] = STATE(164),
-    [sym_parrot_binding] = STATE(175),
-    [sym_key_action] = STATE(174),
-    [sym_identifier] = STATE(173),
-    [aux_sym_matches_repeat1] = STATE(79),
-    [aux_sym_matches_repeat2] = STATE(146),
-    [aux_sym_match_repeat1] = STATE(117),
-    [aux_sym_declarations_repeat1] = STATE(4),
+    [sym_match_modifier] = STATE(134),
+    [sym_match] = STATE(95),
+    [sym_declarations] = STATE(193),
+    [sym_declaration] = STATE(3),
+    [sym_command_declaration] = STATE(53),
+    [sym_app_declaration] = STATE(53),
+    [sym_face_declaration] = STATE(53),
+    [sym_deck_declaration] = STATE(53),
+    [sym_gamepad_declaration] = STATE(53),
+    [sym_noise_declaration] = STATE(53),
+    [sym_parrot_declaration] = STATE(53),
+    [sym_tag_import_declaration] = STATE(53),
+    [sym_key_binding_declaration] = STATE(53),
+    [sym_settings_declaration] = STATE(53),
+    [sym_rule] = STATE(226),
+    [sym__optional_choice] = STATE(190),
+    [sym_choice] = STATE(190),
+    [sym__optional_anchor] = STATE(152),
+    [sym__optional_seq] = STATE(150),
+    [sym_seq] = STATE(150),
+    [sym__primary_rule] = STATE(22),
+    [sym_word] = STATE(22),
+    [sym_list] = STATE(22),
+    [sym_capture] = STATE(22),
+    [sym_optional] = STATE(22),
+    [sym_repeat] = STATE(22),
+    [sym_repeat1] = STATE(22),
+    [sym_parenthesized_rule] = STATE(22),
+    [sym_app_binding] = STATE(217),
+    [sym_face_binding] = STATE(215),
+    [sym_deck_binding] = STATE(213),
+    [sym_gamepad_binding] = STATE(199),
+    [sym_noise_binding] = STATE(220),
+    [sym_parrot_binding] = STATE(224),
+    [sym_key_action] = STATE(223),
+    [sym_identifier] = STATE(222),
+    [aux_sym_matches_repeat1] = STATE(95),
+    [aux_sym_matches_repeat2] = STATE(170),
+    [aux_sym_match_repeat1] = STATE(134),
+    [aux_sym_declarations_repeat1] = STATE(3),
     [ts_builtin_sym_end] = ACTIONS(5),
     [sym_comment] = ACTIONS(3),
     [sym__simple_identifier] = ACTIONS(7),
@@ -3595,39 +3785,39 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_key_LPAREN,
     ACTIONS(45), 1,
       ts_builtin_sym_end,
-    STATE(140), 1,
+    STATE(152), 1,
       sym__optional_anchor,
-    STATE(164), 1,
-      sym_noise_binding,
-    STATE(174), 1,
-      sym_key_action,
-    STATE(175), 1,
-      sym_parrot_binding,
-    STATE(177), 1,
-      sym_gamepad_binding,
-    STATE(178), 1,
-      sym_deck_binding,
-    STATE(179), 1,
-      sym_face_binding,
-    STATE(180), 1,
-      sym_app_binding,
-    STATE(184), 1,
-      sym_rule,
-    STATE(206), 1,
+    STATE(195), 1,
       sym_declarations,
+    STATE(199), 1,
+      sym_gamepad_binding,
+    STATE(213), 1,
+      sym_deck_binding,
+    STATE(215), 1,
+      sym_face_binding,
+    STATE(217), 1,
+      sym_app_binding,
+    STATE(220), 1,
+      sym_noise_binding,
+    STATE(223), 1,
+      sym_key_action,
+    STATE(224), 1,
+      sym_parrot_binding,
+    STATE(226), 1,
+      sym_rule,
     ACTIONS(15), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    STATE(4), 2,
+    STATE(3), 2,
       sym_declaration,
       aux_sym_declarations_repeat1,
-    STATE(134), 2,
+    STATE(150), 2,
       sym__optional_seq,
       sym_seq,
-    STATE(183), 2,
+    STATE(190), 2,
       sym__optional_choice,
       sym_choice,
-    STATE(18), 8,
+    STATE(22), 8,
       sym__primary_rule,
       sym_word,
       sym_list,
@@ -3636,7 +3826,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_repeat,
       sym_repeat1,
       sym_parenthesized_rule,
-    STATE(44), 10,
+    STATE(53), 10,
       sym_command_declaration,
       sym_app_declaration,
       sym_face_declaration,
@@ -3648,89 +3838,6 @@ static const uint16_t ts_small_parse_table[] = {
       sym_key_binding_declaration,
       sym_settings_declaration,
   [117] = 31,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(47), 1,
-      ts_builtin_sym_end,
-    ACTIONS(52), 1,
-      sym_start_anchor,
-    ACTIONS(55), 1,
-      anon_sym_LBRACE,
-    ACTIONS(58), 1,
-      anon_sym_LT,
-    ACTIONS(61), 1,
-      anon_sym_LBRACK,
-    ACTIONS(64), 1,
-      anon_sym_LPAREN,
-    ACTIONS(67), 1,
-      anon_sym_app_LPAREN,
-    ACTIONS(70), 1,
-      anon_sym_face_LPAREN,
-    ACTIONS(73), 1,
-      anon_sym_deck_LPAREN,
-    ACTIONS(76), 1,
-      anon_sym_gamepad_LPAREN,
-    ACTIONS(79), 1,
-      anon_sym_noise_LPAREN,
-    ACTIONS(82), 1,
-      anon_sym_parrot_LPAREN,
-    ACTIONS(85), 1,
-      sym_settings_binding,
-    ACTIONS(88), 1,
-      sym_tag_binding,
-    ACTIONS(91), 1,
-      anon_sym_key_LPAREN,
-    STATE(140), 1,
-      sym__optional_anchor,
-    STATE(164), 1,
-      sym_noise_binding,
-    STATE(174), 1,
-      sym_key_action,
-    STATE(175), 1,
-      sym_parrot_binding,
-    STATE(177), 1,
-      sym_gamepad_binding,
-    STATE(178), 1,
-      sym_deck_binding,
-    STATE(179), 1,
-      sym_face_binding,
-    STATE(180), 1,
-      sym_app_binding,
-    STATE(184), 1,
-      sym_rule,
-    ACTIONS(49), 2,
-      sym__simple_identifier,
-      aux_sym_word_token1,
-    STATE(3), 2,
-      sym_declaration,
-      aux_sym_declarations_repeat1,
-    STATE(134), 2,
-      sym__optional_seq,
-      sym_seq,
-    STATE(183), 2,
-      sym__optional_choice,
-      sym_choice,
-    STATE(18), 8,
-      sym__primary_rule,
-      sym_word,
-      sym_list,
-      sym_capture,
-      sym_optional,
-      sym_repeat,
-      sym_repeat1,
-      sym_parenthesized_rule,
-    STATE(44), 10,
-      sym_command_declaration,
-      sym_app_declaration,
-      sym_face_declaration,
-      sym_deck_declaration,
-      sym_gamepad_declaration,
-      sym_noise_declaration,
-      sym_parrot_declaration,
-      sym_tag_import_declaration,
-      sym_key_binding_declaration,
-      sym_settings_declaration,
-  [231] = 31,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(13), 1,
@@ -3761,39 +3868,39 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tag_binding,
     ACTIONS(41), 1,
       anon_sym_key_LPAREN,
-    ACTIONS(94), 1,
+    ACTIONS(47), 1,
       ts_builtin_sym_end,
-    STATE(140), 1,
+    STATE(152), 1,
       sym__optional_anchor,
-    STATE(164), 1,
-      sym_noise_binding,
-    STATE(174), 1,
-      sym_key_action,
-    STATE(175), 1,
-      sym_parrot_binding,
-    STATE(177), 1,
+    STATE(199), 1,
       sym_gamepad_binding,
-    STATE(178), 1,
+    STATE(213), 1,
       sym_deck_binding,
-    STATE(179), 1,
+    STATE(215), 1,
       sym_face_binding,
-    STATE(180), 1,
+    STATE(217), 1,
       sym_app_binding,
-    STATE(184), 1,
+    STATE(220), 1,
+      sym_noise_binding,
+    STATE(223), 1,
+      sym_key_action,
+    STATE(224), 1,
+      sym_parrot_binding,
+    STATE(226), 1,
       sym_rule,
     ACTIONS(15), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    STATE(3), 2,
+    STATE(4), 2,
       sym_declaration,
       aux_sym_declarations_repeat1,
-    STATE(134), 2,
+    STATE(150), 2,
       sym__optional_seq,
       sym_seq,
-    STATE(183), 2,
+    STATE(190), 2,
       sym__optional_choice,
       sym_choice,
-    STATE(18), 8,
+    STATE(22), 8,
       sym__primary_rule,
       sym_word,
       sym_list,
@@ -3802,7 +3909,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_repeat,
       sym_repeat1,
       sym_parenthesized_rule,
-    STATE(44), 10,
+    STATE(53), 10,
       sym_command_declaration,
       sym_app_declaration,
       sym_face_declaration,
@@ -3813,40 +3920,698 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tag_import_declaration,
       sym_key_binding_declaration,
       sym_settings_declaration,
-  [345] = 13,
-    ACTIONS(96), 1,
+  [231] = 31,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(49), 1,
+      ts_builtin_sym_end,
+    ACTIONS(54), 1,
+      sym_start_anchor,
+    ACTIONS(57), 1,
+      anon_sym_LBRACE,
+    ACTIONS(60), 1,
+      anon_sym_LT,
+    ACTIONS(63), 1,
+      anon_sym_LBRACK,
+    ACTIONS(66), 1,
+      anon_sym_LPAREN,
+    ACTIONS(69), 1,
+      anon_sym_app_LPAREN,
+    ACTIONS(72), 1,
+      anon_sym_face_LPAREN,
+    ACTIONS(75), 1,
+      anon_sym_deck_LPAREN,
+    ACTIONS(78), 1,
+      anon_sym_gamepad_LPAREN,
+    ACTIONS(81), 1,
+      anon_sym_noise_LPAREN,
+    ACTIONS(84), 1,
+      anon_sym_parrot_LPAREN,
+    ACTIONS(87), 1,
+      sym_settings_binding,
+    ACTIONS(90), 1,
+      sym_tag_binding,
+    ACTIONS(93), 1,
+      anon_sym_key_LPAREN,
+    STATE(152), 1,
+      sym__optional_anchor,
+    STATE(199), 1,
+      sym_gamepad_binding,
+    STATE(213), 1,
+      sym_deck_binding,
+    STATE(215), 1,
+      sym_face_binding,
+    STATE(217), 1,
+      sym_app_binding,
+    STATE(220), 1,
+      sym_noise_binding,
+    STATE(223), 1,
+      sym_key_action,
+    STATE(224), 1,
+      sym_parrot_binding,
+    STATE(226), 1,
+      sym_rule,
+    ACTIONS(51), 2,
+      sym__simple_identifier,
+      aux_sym_word_token1,
+    STATE(4), 2,
+      sym_declaration,
+      aux_sym_declarations_repeat1,
+    STATE(150), 2,
+      sym__optional_seq,
+      sym_seq,
+    STATE(190), 2,
+      sym__optional_choice,
+      sym_choice,
+    STATE(22), 8,
+      sym__primary_rule,
+      sym_word,
+      sym_list,
+      sym_capture,
+      sym_optional,
+      sym_repeat,
+      sym_repeat1,
+      sym_parenthesized_rule,
+    STATE(53), 10,
+      sym_command_declaration,
+      sym_app_declaration,
+      sym_face_declaration,
+      sym_deck_declaration,
+      sym_gamepad_declaration,
+      sym_noise_declaration,
+      sym_parrot_declaration,
+      sym_tag_import_declaration,
+      sym_key_binding_declaration,
+      sym_settings_declaration,
+  [345] = 18,
+    ACTIONS(3), 1,
       sym_comment,
     ACTIONS(98), 1,
       anon_sym_DASH,
-    ACTIONS(102), 1,
+    ACTIONS(100), 1,
       anon_sym_LPAREN,
+    ACTIONS(102), 1,
+      anon_sym_if,
     ACTIONS(104), 1,
-      anon_sym_key_LPAREN,
+      anon_sym_for,
     ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
       anon_sym_sleep_LPAREN,
     ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
+    ACTIONS(114), 1,
+      sym__dedent,
+    ACTIONS(116), 1,
       sym__string_start,
-    STATE(80), 1,
+    STATE(60), 1,
+      sym_block,
+    STATE(103), 1,
       sym_identifier,
-    STATE(118), 1,
+    STATE(123), 1,
+      sym_expression,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(14), 2,
+      sym_statement,
+      aux_sym_block_repeat1,
+    STATE(93), 4,
+      sym_if_statement,
+      sym_for_statement,
+      sym_assignment_statement,
+      sym_expression_statement,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [412] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
+    ACTIONS(116), 1,
+      sym__string_start,
+    ACTIONS(118), 1,
+      anon_sym_if,
+    ACTIONS(120), 1,
+      anon_sym_for,
+    ACTIONS(122), 1,
+      sym__indent,
+    STATE(65), 1,
+      sym__statements,
+    STATE(72), 1,
+      sym_statement,
+    STATE(97), 1,
+      sym_identifier,
+    STATE(140), 1,
+      sym_expression,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(71), 4,
+      sym_if_statement,
+      sym_for_statement,
+      sym_assignment_statement,
+      sym_expression_statement,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [478] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
+    ACTIONS(116), 1,
+      sym__string_start,
+    ACTIONS(118), 1,
+      anon_sym_if,
+    ACTIONS(120), 1,
+      anon_sym_for,
+    ACTIONS(122), 1,
+      sym__indent,
+    STATE(51), 1,
+      sym__statements,
+    STATE(72), 1,
+      sym_statement,
+    STATE(97), 1,
+      sym_identifier,
+    STATE(140), 1,
+      sym_expression,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(71), 4,
+      sym_if_statement,
+      sym_for_statement,
+      sym_assignment_statement,
+      sym_expression_statement,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [544] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
+    ACTIONS(116), 1,
+      sym__string_start,
+    ACTIONS(118), 1,
+      anon_sym_if,
+    ACTIONS(120), 1,
+      anon_sym_for,
+    ACTIONS(122), 1,
+      sym__indent,
+    STATE(66), 1,
+      sym__statements,
+    STATE(72), 1,
+      sym_statement,
+    STATE(97), 1,
+      sym_identifier,
+    STATE(140), 1,
+      sym_expression,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(71), 4,
+      sym_if_statement,
+      sym_for_statement,
+      sym_assignment_statement,
+      sym_expression_statement,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [610] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
+    ACTIONS(116), 1,
+      sym__string_start,
+    ACTIONS(118), 1,
+      anon_sym_if,
+    ACTIONS(120), 1,
+      anon_sym_for,
+    ACTIONS(122), 1,
+      sym__indent,
+    STATE(67), 1,
+      sym__statements,
+    STATE(72), 1,
+      sym_statement,
+    STATE(97), 1,
+      sym_identifier,
+    STATE(140), 1,
+      sym_expression,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(71), 4,
+      sym_if_statement,
+      sym_for_statement,
+      sym_assignment_statement,
+      sym_expression_statement,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [676] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
+    ACTIONS(116), 1,
+      sym__string_start,
+    ACTIONS(118), 1,
+      anon_sym_if,
+    ACTIONS(120), 1,
+      anon_sym_for,
+    ACTIONS(122), 1,
+      sym__indent,
+    STATE(68), 1,
+      sym__statements,
+    STATE(72), 1,
+      sym_statement,
+    STATE(97), 1,
+      sym_identifier,
+    STATE(140), 1,
+      sym_expression,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(71), 4,
+      sym_if_statement,
+      sym_for_statement,
+      sym_assignment_statement,
+      sym_expression_statement,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [742] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
+    ACTIONS(116), 1,
+      sym__string_start,
+    ACTIONS(118), 1,
+      anon_sym_if,
+    ACTIONS(120), 1,
+      anon_sym_for,
+    ACTIONS(122), 1,
+      sym__indent,
+    STATE(70), 1,
+      sym__statements,
+    STATE(72), 1,
+      sym_statement,
+    STATE(97), 1,
+      sym_identifier,
+    STATE(140), 1,
+      sym_expression,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(71), 4,
+      sym_if_statement,
+      sym_for_statement,
+      sym_assignment_statement,
+      sym_expression_statement,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [808] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
+    ACTIONS(116), 1,
+      sym__string_start,
+    ACTIONS(118), 1,
+      anon_sym_if,
+    ACTIONS(120), 1,
+      anon_sym_for,
+    ACTIONS(122), 1,
+      sym__indent,
+    STATE(63), 1,
+      sym__statements,
+    STATE(72), 1,
+      sym_statement,
+    STATE(97), 1,
+      sym_identifier,
+    STATE(140), 1,
+      sym_expression,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(71), 4,
+      sym_if_statement,
+      sym_for_statement,
+      sym_assignment_statement,
+      sym_expression_statement,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [874] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
+    ACTIONS(116), 1,
+      sym__string_start,
+    ACTIONS(118), 1,
+      anon_sym_if,
+    ACTIONS(120), 1,
+      anon_sym_for,
+    ACTIONS(122), 1,
+      sym__indent,
+    STATE(54), 1,
+      sym__statements,
+    STATE(72), 1,
+      sym_statement,
+    STATE(97), 1,
+      sym_identifier,
+    STATE(140), 1,
+      sym_expression,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(71), 4,
+      sym_if_statement,
+      sym_for_statement,
+      sym_assignment_statement,
+      sym_expression_statement,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [940] = 17,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(102), 1,
+      anon_sym_if,
+    ACTIONS(104), 1,
+      anon_sym_for,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
+    ACTIONS(116), 1,
+      sym__string_start,
+    ACTIONS(124), 1,
+      sym__dedent,
+    STATE(103), 1,
+      sym_identifier,
+    STATE(123), 1,
+      sym_expression,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(15), 2,
+      sym_statement,
+      aux_sym_block_repeat1,
+    STATE(93), 4,
+      sym_if_statement,
+      sym_for_statement,
+      sym_assignment_statement,
+      sym_expression_statement,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [1004] = 17,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(129), 1,
+      anon_sym_DASH,
+    ACTIONS(132), 1,
+      anon_sym_LPAREN,
+    ACTIONS(135), 1,
+      anon_sym_if,
+    ACTIONS(138), 1,
+      anon_sym_for,
+    ACTIONS(141), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(144), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(147), 1,
+      sym_integer,
+    ACTIONS(150), 1,
+      sym_float,
+    ACTIONS(153), 1,
+      sym__dedent,
+    ACTIONS(155), 1,
+      sym__string_start,
+    STATE(103), 1,
+      sym_identifier,
+    STATE(123), 1,
+      sym_expression,
+    ACTIONS(126), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(15), 2,
+      sym_statement,
+      aux_sym_block_repeat1,
+    STATE(93), 4,
+      sym_if_statement,
+      sym_for_statement,
+      sym_assignment_statement,
+      sym_expression_statement,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [1068] = 18,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
+    ACTIONS(116), 1,
+      sym__string_start,
+    ACTIONS(118), 1,
+      anon_sym_if,
+    ACTIONS(120), 1,
+      anon_sym_for,
+    ACTIONS(122), 1,
+      sym__indent,
+    STATE(64), 1,
+      sym__statements,
+    STATE(72), 1,
+      sym_statement,
+    STATE(97), 1,
+      sym_identifier,
+    STATE(140), 1,
+      sym_expression,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(71), 4,
+      sym_if_statement,
+      sym_for_statement,
+      sym_assignment_statement,
+      sym_expression_statement,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [1134] = 13,
+    ACTIONS(158), 1,
+      sym_comment,
+    ACTIONS(160), 1,
+      anon_sym_DASH,
+    ACTIONS(164), 1,
+      anon_sym_LPAREN,
+    ACTIONS(166), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(168), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(172), 1,
+      sym__string_start,
+    STATE(90), 1,
+      sym_identifier,
+    STATE(141), 1,
       sym_expression,
     ACTIONS(43), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    ACTIONS(108), 2,
+    ACTIONS(170), 2,
       sym_integer,
       sym_float,
-    ACTIONS(112), 2,
+    ACTIONS(174), 2,
       sym_string_content,
       sym__string_end,
-    ACTIONS(100), 6,
+    ACTIONS(162), 6,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_LBRACE_LBRACE,
       anon_sym_RBRACE_RBRACE,
       sym_string_escape_sequence,
       sym__not_escapesequence,
-    STATE(102), 8,
+    STATE(100), 8,
       sym_variable,
       sym_parenthesized_expression,
       sym_binary_operator,
@@ -3855,83 +4620,42 @@ static const uint16_t ts_small_parse_table[] = {
       sym_sleep_action,
       sym_action,
       sym_string,
-  [400] = 16,
+  [1189] = 16,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(116), 1,
+    ACTIONS(98), 1,
       anon_sym_DASH,
-    ACTIONS(118), 1,
+    ACTIONS(100), 1,
       anon_sym_LPAREN,
-    ACTIONS(120), 1,
+    ACTIONS(106), 1,
       anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
+    ACTIONS(108), 1,
       anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
+    ACTIONS(110), 1,
       sym_integer,
-    ACTIONS(126), 1,
+    ACTIONS(112), 1,
       sym_float,
-    ACTIONS(128), 1,
-      sym__dedent,
-    ACTIONS(130), 1,
-      sym__string_start,
-    STATE(53), 1,
-      sym_block,
-    STATE(82), 1,
-      sym_identifier,
-    STATE(114), 1,
-      sym_expression,
-    ACTIONS(114), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(9), 2,
-      sym_statement,
-      aux_sym_block_repeat1,
-    STATE(84), 2,
-      sym_assignment_statement,
-      sym_expression_statement,
-    STATE(112), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [459] = 16,
-    ACTIONS(3), 1,
-      sym_comment,
     ACTIONS(116), 1,
-      anon_sym_DASH,
-    ACTIONS(118), 1,
-      anon_sym_LPAREN,
-    ACTIONS(120), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
-      sym_integer,
-    ACTIONS(126), 1,
-      sym_float,
-    ACTIONS(130), 1,
       sym__string_start,
-    ACTIONS(132), 1,
-      sym__indent,
+    ACTIONS(118), 1,
+      anon_sym_if,
+    ACTIONS(120), 1,
+      anon_sym_for,
     STATE(57), 1,
-      sym__statements,
-    STATE(60), 1,
       sym_statement,
-    STATE(85), 1,
+    STATE(97), 1,
       sym_identifier,
-    STATE(121), 1,
+    STATE(140), 1,
       sym_expression,
-    ACTIONS(114), 2,
+    ACTIONS(96), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    STATE(52), 2,
+    STATE(71), 4,
+      sym_if_statement,
+      sym_for_statement,
       sym_assignment_statement,
       sym_expression_statement,
-    STATE(112), 8,
+    STATE(143), 8,
       sym_variable,
       sym_parenthesized_expression,
       sym_binary_operator,
@@ -3940,40 +4664,42 @@ static const uint16_t ts_small_parse_table[] = {
       sym_sleep_action,
       sym_action,
       sym_string,
-  [517] = 16,
+  [1249] = 16,
     ACTIONS(3), 1,
       sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(102), 1,
+      anon_sym_if,
+    ACTIONS(104), 1,
+      anon_sym_for,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
     ACTIONS(116), 1,
-      anon_sym_DASH,
-    ACTIONS(118), 1,
-      anon_sym_LPAREN,
-    ACTIONS(120), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
-      sym_integer,
-    ACTIONS(126), 1,
-      sym_float,
-    ACTIONS(130), 1,
       sym__string_start,
-    ACTIONS(132), 1,
-      sym__indent,
-    STATE(59), 1,
-      sym__statements,
-    STATE(60), 1,
+    STATE(83), 1,
       sym_statement,
-    STATE(85), 1,
+    STATE(103), 1,
       sym_identifier,
-    STATE(121), 1,
+    STATE(123), 1,
       sym_expression,
-    ACTIONS(114), 2,
+    ACTIONS(96), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    STATE(52), 2,
+    STATE(93), 4,
+      sym_if_statement,
+      sym_for_statement,
       sym_assignment_statement,
       sym_expression_statement,
-    STATE(112), 8,
+    STATE(143), 8,
       sym_variable,
       sym_parenthesized_expression,
       sym_binary_operator,
@@ -3982,39 +4708,42 @@ static const uint16_t ts_small_parse_table[] = {
       sym_sleep_action,
       sym_action,
       sym_string,
-  [575] = 15,
+  [1309] = 16,
     ACTIONS(3), 1,
       sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(102), 1,
+      anon_sym_if,
+    ACTIONS(104), 1,
+      anon_sym_for,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
     ACTIONS(116), 1,
-      anon_sym_DASH,
-    ACTIONS(118), 1,
-      anon_sym_LPAREN,
-    ACTIONS(120), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
-      sym_integer,
-    ACTIONS(126), 1,
-      sym_float,
-    ACTIONS(130), 1,
       sym__string_start,
-    ACTIONS(134), 1,
-      sym__dedent,
-    STATE(82), 1,
+    STATE(91), 1,
+      sym_statement,
+    STATE(103), 1,
       sym_identifier,
-    STATE(114), 1,
+    STATE(123), 1,
       sym_expression,
-    ACTIONS(114), 2,
+    ACTIONS(96), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    STATE(11), 2,
-      sym_statement,
-      aux_sym_block_repeat1,
-    STATE(84), 2,
+    STATE(93), 4,
+      sym_if_statement,
+      sym_for_statement,
       sym_assignment_statement,
       sym_expression_statement,
-    STATE(112), 8,
+    STATE(143), 8,
       sym_variable,
       sym_parenthesized_expression,
       sym_binary_operator,
@@ -4023,40 +4752,42 @@ static const uint16_t ts_small_parse_table[] = {
       sym_sleep_action,
       sym_action,
       sym_string,
-  [631] = 16,
+  [1369] = 16,
     ACTIONS(3), 1,
       sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
     ACTIONS(116), 1,
-      anon_sym_DASH,
+      sym__string_start,
     ACTIONS(118), 1,
-      anon_sym_LPAREN,
+      anon_sym_if,
     ACTIONS(120), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
-      sym_integer,
-    ACTIONS(126), 1,
-      sym_float,
-    ACTIONS(130), 1,
-      sym__string_start,
-    ACTIONS(132), 1,
-      sym__indent,
-    STATE(60), 1,
+      anon_sym_for,
+    STATE(69), 1,
       sym_statement,
-    STATE(61), 1,
-      sym__statements,
-    STATE(85), 1,
+    STATE(97), 1,
       sym_identifier,
-    STATE(121), 1,
+    STATE(140), 1,
       sym_expression,
-    ACTIONS(114), 2,
+    ACTIONS(96), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    STATE(52), 2,
+    STATE(71), 4,
+      sym_if_statement,
+      sym_for_statement,
       sym_assignment_statement,
       sym_expression_statement,
-    STATE(112), 8,
+    STATE(143), 8,
       sym_variable,
       sym_parenthesized_expression,
       sym_binary_operator,
@@ -4065,300 +4796,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_sleep_action,
       sym_action,
       sym_string,
-  [689] = 15,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(139), 1,
-      anon_sym_DASH,
-    ACTIONS(142), 1,
-      anon_sym_LPAREN,
-    ACTIONS(145), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(148), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(151), 1,
-      sym_integer,
-    ACTIONS(154), 1,
-      sym_float,
-    ACTIONS(157), 1,
-      sym__dedent,
-    ACTIONS(159), 1,
-      sym__string_start,
-    STATE(82), 1,
-      sym_identifier,
-    STATE(114), 1,
-      sym_expression,
-    ACTIONS(136), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(11), 2,
-      sym_statement,
-      aux_sym_block_repeat1,
-    STATE(84), 2,
-      sym_assignment_statement,
-      sym_expression_statement,
-    STATE(112), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [745] = 16,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(116), 1,
-      anon_sym_DASH,
-    ACTIONS(118), 1,
-      anon_sym_LPAREN,
-    ACTIONS(120), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
-      sym_integer,
-    ACTIONS(126), 1,
-      sym_float,
-    ACTIONS(130), 1,
-      sym__string_start,
-    ACTIONS(132), 1,
-      sym__indent,
-    STATE(45), 1,
-      sym__statements,
-    STATE(60), 1,
-      sym_statement,
-    STATE(85), 1,
-      sym_identifier,
-    STATE(121), 1,
-      sym_expression,
-    ACTIONS(114), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(52), 2,
-      sym_assignment_statement,
-      sym_expression_statement,
-    STATE(112), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [803] = 16,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(116), 1,
-      anon_sym_DASH,
-    ACTIONS(118), 1,
-      anon_sym_LPAREN,
-    ACTIONS(120), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
-      sym_integer,
-    ACTIONS(126), 1,
-      sym_float,
-    ACTIONS(130), 1,
-      sym__string_start,
-    ACTIONS(132), 1,
-      sym__indent,
-    STATE(60), 1,
-      sym_statement,
-    STATE(62), 1,
-      sym__statements,
-    STATE(85), 1,
-      sym_identifier,
-    STATE(121), 1,
-      sym_expression,
-    ACTIONS(114), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(52), 2,
-      sym_assignment_statement,
-      sym_expression_statement,
-    STATE(112), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [861] = 16,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(116), 1,
-      anon_sym_DASH,
-    ACTIONS(118), 1,
-      anon_sym_LPAREN,
-    ACTIONS(120), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
-      sym_integer,
-    ACTIONS(126), 1,
-      sym_float,
-    ACTIONS(130), 1,
-      sym__string_start,
-    ACTIONS(132), 1,
-      sym__indent,
-    STATE(49), 1,
-      sym__statements,
-    STATE(60), 1,
-      sym_statement,
-    STATE(85), 1,
-      sym_identifier,
-    STATE(121), 1,
-      sym_expression,
-    ACTIONS(114), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(52), 2,
-      sym_assignment_statement,
-      sym_expression_statement,
-    STATE(112), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [919] = 16,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(116), 1,
-      anon_sym_DASH,
-    ACTIONS(118), 1,
-      anon_sym_LPAREN,
-    ACTIONS(120), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
-      sym_integer,
-    ACTIONS(126), 1,
-      sym_float,
-    ACTIONS(130), 1,
-      sym__string_start,
-    ACTIONS(132), 1,
-      sym__indent,
-    STATE(47), 1,
-      sym__statements,
-    STATE(60), 1,
-      sym_statement,
-    STATE(85), 1,
-      sym_identifier,
-    STATE(121), 1,
-      sym_expression,
-    ACTIONS(114), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(52), 2,
-      sym_assignment_statement,
-      sym_expression_statement,
-    STATE(112), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [977] = 16,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(116), 1,
-      anon_sym_DASH,
-    ACTIONS(118), 1,
-      anon_sym_LPAREN,
-    ACTIONS(120), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
-      sym_integer,
-    ACTIONS(126), 1,
-      sym_float,
-    ACTIONS(130), 1,
-      sym__string_start,
-    ACTIONS(132), 1,
-      sym__indent,
-    STATE(50), 1,
-      sym__statements,
-    STATE(60), 1,
-      sym_statement,
-    STATE(85), 1,
-      sym_identifier,
-    STATE(121), 1,
-      sym_expression,
-    ACTIONS(114), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(52), 2,
-      sym_assignment_statement,
-      sym_expression_statement,
-    STATE(112), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [1035] = 16,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(116), 1,
-      anon_sym_DASH,
-    ACTIONS(118), 1,
-      anon_sym_LPAREN,
-    ACTIONS(120), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
-      sym_integer,
-    ACTIONS(126), 1,
-      sym_float,
-    ACTIONS(130), 1,
-      sym__string_start,
-    ACTIONS(132), 1,
-      sym__indent,
-    STATE(46), 1,
-      sym__statements,
-    STATE(60), 1,
-      sym_statement,
-    STATE(85), 1,
-      sym_identifier,
-    STATE(121), 1,
-      sym_expression,
-    ACTIONS(114), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(52), 2,
-      sym_assignment_statement,
-      sym_expression_statement,
-    STATE(112), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [1093] = 11,
+  [1429] = 11,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(17), 1,
@@ -4369,22 +4807,22 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACK,
     ACTIONS(23), 1,
       anon_sym_LPAREN,
-    ACTIONS(164), 1,
+    ACTIONS(178), 1,
       anon_sym_STAR,
-    ACTIONS(166), 1,
+    ACTIONS(180), 1,
       anon_sym_PLUS,
-    STATE(25), 1,
+    STATE(29), 1,
       aux_sym_seq_repeat1,
     ACTIONS(15), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(162), 5,
+    ACTIONS(176), 5,
       anon_sym_COLON,
       anon_sym_PIPE,
       sym_end_anchor,
       anon_sym_RBRACK,
       anon_sym_RPAREN,
-    STATE(64), 8,
+    STATE(78), 8,
       sym__primary_rule,
       sym_word,
       sym_list,
@@ -4393,35 +4831,35 @@ static const uint16_t ts_small_parse_table[] = {
       sym_repeat,
       sym_repeat1,
       sym_parenthesized_rule,
-  [1139] = 14,
+  [1475] = 14,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(41), 1,
       anon_sym_key_LPAREN,
-    ACTIONS(108), 1,
-      sym_integer,
-    ACTIONS(110), 1,
-      sym__string_start,
-    ACTIONS(168), 1,
-      anon_sym_DASH,
     ACTIONS(170), 1,
-      anon_sym_LPAREN,
+      sym_integer,
     ACTIONS(172), 1,
+      sym__string_start,
+    ACTIONS(182), 1,
+      anon_sym_DASH,
+    ACTIONS(184), 1,
+      anon_sym_LPAREN,
+    ACTIONS(186), 1,
       anon_sym_RPAREN,
-    ACTIONS(174), 1,
+    ACTIONS(188), 1,
       anon_sym_sleep_LPAREN,
-    ACTIONS(176), 1,
+    ACTIONS(190), 1,
       anon_sym_COMMA,
-    ACTIONS(178), 1,
+    ACTIONS(192), 1,
       sym_float,
-    STATE(80), 1,
+    STATE(90), 1,
       sym_identifier,
-    STATE(91), 1,
+    STATE(114), 1,
       sym_expression,
     ACTIONS(43), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    STATE(102), 8,
+    STATE(100), 8,
       sym_variable,
       sym_parenthesized_expression,
       sym_binary_operator,
@@ -4430,35 +4868,402 @@ static const uint16_t ts_small_parse_table[] = {
       sym_sleep_action,
       sym_action,
       sym_string,
-  [1190] = 14,
+  [1526] = 14,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(41), 1,
       anon_sym_key_LPAREN,
-    ACTIONS(108), 1,
-      sym_integer,
-    ACTIONS(110), 1,
-      sym__string_start,
-    ACTIONS(168), 1,
-      anon_sym_DASH,
     ACTIONS(170), 1,
-      anon_sym_LPAREN,
-    ACTIONS(174), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(178), 1,
-      sym_float,
-    ACTIONS(180), 1,
-      anon_sym_RPAREN,
+      sym_integer,
+    ACTIONS(172), 1,
+      sym__string_start,
     ACTIONS(182), 1,
+      anon_sym_DASH,
+    ACTIONS(184), 1,
+      anon_sym_LPAREN,
+    ACTIONS(188), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(192), 1,
+      sym_float,
+    ACTIONS(194), 1,
+      anon_sym_RPAREN,
+    ACTIONS(196), 1,
       anon_sym_COMMA,
-    STATE(80), 1,
+    STATE(90), 1,
+      sym_identifier,
+    STATE(115), 1,
+      sym_expression,
+    ACTIONS(43), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(100), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [1577] = 11,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(13), 1,
+      sym_start_anchor,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE,
+    ACTIONS(19), 1,
+      anon_sym_LT,
+    ACTIONS(21), 1,
+      anon_sym_LBRACK,
+    ACTIONS(23), 1,
+      anon_sym_LPAREN,
+    STATE(152), 1,
+      sym__optional_anchor,
+    ACTIONS(15), 2,
+      sym__simple_identifier,
+      aux_sym_word_token1,
+    STATE(150), 2,
+      sym__optional_seq,
+      sym_seq,
+    STATE(183), 2,
+      sym__optional_choice,
+      sym_choice,
+    STATE(22), 8,
+      sym__primary_rule,
+      sym_word,
+      sym_list,
+      sym_capture,
+      sym_optional,
+      sym_repeat,
+      sym_repeat1,
+      sym_parenthesized_rule,
+  [1621] = 9,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(203), 1,
+      anon_sym_LBRACE,
+    ACTIONS(206), 1,
+      anon_sym_LT,
+    ACTIONS(209), 1,
+      anon_sym_LBRACK,
+    ACTIONS(212), 1,
+      anon_sym_LPAREN,
+    STATE(26), 1,
+      aux_sym_seq_repeat1,
+    ACTIONS(198), 2,
+      sym__simple_identifier,
+      aux_sym_word_token1,
+    ACTIONS(201), 5,
+      anon_sym_COLON,
+      anon_sym_PIPE,
+      sym_end_anchor,
+      anon_sym_RBRACK,
+      anon_sym_RPAREN,
+    STATE(78), 8,
+      sym__primary_rule,
+      sym_word,
+      sym_list,
+      sym_capture,
+      sym_optional,
+      sym_repeat,
+      sym_repeat1,
+      sym_parenthesized_rule,
+  [1661] = 13,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(41), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(170), 1,
+      sym_integer,
+    ACTIONS(172), 1,
+      sym__string_start,
+    ACTIONS(182), 1,
+      anon_sym_DASH,
+    ACTIONS(184), 1,
+      anon_sym_LPAREN,
+    ACTIONS(188), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(192), 1,
+      sym_float,
+    ACTIONS(215), 1,
+      anon_sym_RPAREN,
+    STATE(90), 1,
+      sym_identifier,
+    STATE(120), 1,
+      sym_expression,
+    ACTIONS(43), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(100), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [1709] = 13,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(41), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(170), 1,
+      sym_integer,
+    ACTIONS(172), 1,
+      sym__string_start,
+    ACTIONS(182), 1,
+      anon_sym_DASH,
+    ACTIONS(184), 1,
+      anon_sym_LPAREN,
+    ACTIONS(188), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(192), 1,
+      sym_float,
+    ACTIONS(217), 1,
+      anon_sym_RPAREN,
+    STATE(90), 1,
+      sym_identifier,
+    STATE(120), 1,
+      sym_expression,
+    ACTIONS(43), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(100), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [1757] = 9,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE,
+    ACTIONS(19), 1,
+      anon_sym_LT,
+    ACTIONS(21), 1,
+      anon_sym_LBRACK,
+    ACTIONS(23), 1,
+      anon_sym_LPAREN,
+    STATE(26), 1,
+      aux_sym_seq_repeat1,
+    ACTIONS(15), 2,
+      sym__simple_identifier,
+      aux_sym_word_token1,
+    ACTIONS(219), 5,
+      anon_sym_COLON,
+      anon_sym_PIPE,
+      sym_end_anchor,
+      anon_sym_RBRACK,
+      anon_sym_RPAREN,
+    STATE(78), 8,
+      sym__primary_rule,
+      sym_word,
+      sym_list,
+      sym_capture,
+      sym_optional,
+      sym_repeat,
+      sym_repeat1,
+      sym_parenthesized_rule,
+  [1797] = 11,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(13), 1,
+      sym_start_anchor,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE,
+    ACTIONS(19), 1,
+      anon_sym_LT,
+    ACTIONS(21), 1,
+      anon_sym_LBRACK,
+    ACTIONS(23), 1,
+      anon_sym_LPAREN,
+    STATE(152), 1,
+      sym__optional_anchor,
+    ACTIONS(15), 2,
+      sym__simple_identifier,
+      aux_sym_word_token1,
+    STATE(150), 2,
+      sym__optional_seq,
+      sym_seq,
+    STATE(209), 2,
+      sym__optional_choice,
+      sym_choice,
+    STATE(22), 8,
+      sym__primary_rule,
+      sym_word,
+      sym_list,
+      sym_capture,
+      sym_optional,
+      sym_repeat,
+      sym_repeat1,
+      sym_parenthesized_rule,
+  [1841] = 13,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(41), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(170), 1,
+      sym_integer,
+    ACTIONS(172), 1,
+      sym__string_start,
+    ACTIONS(182), 1,
+      anon_sym_DASH,
+    ACTIONS(184), 1,
+      anon_sym_LPAREN,
+    ACTIONS(188), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(192), 1,
+      sym_float,
+    ACTIONS(221), 1,
+      anon_sym_RPAREN,
+    STATE(90), 1,
+      sym_identifier,
+    STATE(120), 1,
+      sym_expression,
+    ACTIONS(43), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(100), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [1889] = 13,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(41), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(170), 1,
+      sym_integer,
+    ACTIONS(172), 1,
+      sym__string_start,
+    ACTIONS(182), 1,
+      anon_sym_DASH,
+    ACTIONS(184), 1,
+      anon_sym_LPAREN,
+    ACTIONS(188), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(192), 1,
+      sym_float,
+    ACTIONS(223), 1,
+      anon_sym_RPAREN,
+    STATE(90), 1,
+      sym_identifier,
+    STATE(120), 1,
+      sym_expression,
+    ACTIONS(43), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(100), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [1937] = 12,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(41), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(170), 1,
+      sym_integer,
+    ACTIONS(172), 1,
+      sym__string_start,
+    ACTIONS(182), 1,
+      anon_sym_DASH,
+    ACTIONS(184), 1,
+      anon_sym_LPAREN,
+    ACTIONS(188), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(192), 1,
+      sym_float,
+    STATE(90), 1,
+      sym_identifier,
+    STATE(99), 1,
+      sym_expression,
+    ACTIONS(43), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(100), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [1982] = 12,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(41), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(170), 1,
+      sym_integer,
+    ACTIONS(172), 1,
+      sym__string_start,
+    ACTIONS(182), 1,
+      anon_sym_DASH,
+    ACTIONS(184), 1,
+      anon_sym_LPAREN,
+    ACTIONS(188), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(192), 1,
+      sym_float,
+    STATE(90), 1,
+      sym_identifier,
+    STATE(110), 1,
+      sym_expression,
+    ACTIONS(43), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(100), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [2027] = 12,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(41), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(170), 1,
+      sym_integer,
+    ACTIONS(172), 1,
+      sym__string_start,
+    ACTIONS(182), 1,
+      anon_sym_DASH,
+    ACTIONS(184), 1,
+      anon_sym_LPAREN,
+    ACTIONS(188), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(192), 1,
+      sym_float,
+    STATE(90), 1,
       sym_identifier,
     STATE(104), 1,
       sym_expression,
     ACTIONS(43), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    STATE(102), 8,
+    STATE(100), 8,
       sym_variable,
       sym_parenthesized_expression,
       sym_binary_operator,
@@ -4467,136 +5272,31 @@ static const uint16_t ts_small_parse_table[] = {
       sym_sleep_action,
       sym_action,
       sym_string,
-  [1241] = 11,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(13), 1,
-      sym_start_anchor,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE,
-    ACTIONS(19), 1,
-      anon_sym_LT,
-    ACTIONS(21), 1,
-      anon_sym_LBRACK,
-    ACTIONS(23), 1,
-      anon_sym_LPAREN,
-    STATE(140), 1,
-      sym__optional_anchor,
-    ACTIONS(15), 2,
-      sym__simple_identifier,
-      aux_sym_word_token1,
-    STATE(134), 2,
-      sym__optional_seq,
-      sym_seq,
-    STATE(166), 2,
-      sym__optional_choice,
-      sym_choice,
-    STATE(18), 8,
-      sym__primary_rule,
-      sym_word,
-      sym_list,
-      sym_capture,
-      sym_optional,
-      sym_repeat,
-      sym_repeat1,
-      sym_parenthesized_rule,
-  [1285] = 13,
+  [2072] = 12,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(41), 1,
       anon_sym_key_LPAREN,
-    ACTIONS(108), 1,
-      sym_integer,
-    ACTIONS(110), 1,
-      sym__string_start,
-    ACTIONS(168), 1,
-      anon_sym_DASH,
     ACTIONS(170), 1,
-      anon_sym_LPAREN,
-    ACTIONS(174), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(178), 1,
-      sym_float,
+      sym_integer,
+    ACTIONS(172), 1,
+      sym__string_start,
+    ACTIONS(182), 1,
+      anon_sym_DASH,
     ACTIONS(184), 1,
-      anon_sym_RPAREN,
-    STATE(80), 1,
-      sym_identifier,
-    STATE(108), 1,
-      sym_expression,
-    ACTIONS(43), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(102), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [1333] = 13,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(41), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(108), 1,
-      sym_integer,
-    ACTIONS(110), 1,
-      sym__string_start,
-    ACTIONS(168), 1,
-      anon_sym_DASH,
-    ACTIONS(170), 1,
       anon_sym_LPAREN,
-    ACTIONS(174), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(178), 1,
-      sym_float,
-    ACTIONS(186), 1,
-      anon_sym_RPAREN,
-    STATE(80), 1,
-      sym_identifier,
-    STATE(108), 1,
-      sym_expression,
-    ACTIONS(43), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(102), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [1381] = 13,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(41), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(108), 1,
-      sym_integer,
-    ACTIONS(110), 1,
-      sym__string_start,
-    ACTIONS(168), 1,
-      anon_sym_DASH,
-    ACTIONS(170), 1,
-      anon_sym_LPAREN,
-    ACTIONS(174), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(178), 1,
-      sym_float,
     ACTIONS(188), 1,
-      anon_sym_RPAREN,
-    STATE(80), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(192), 1,
+      sym_float,
+    STATE(90), 1,
       sym_identifier,
-    STATE(108), 1,
+    STATE(120), 1,
       sym_expression,
     ACTIONS(43), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    STATE(102), 8,
+    STATE(100), 8,
       sym_variable,
       sym_parenthesized_expression,
       sym_binary_operator,
@@ -4605,227 +5305,97 @@ static const uint16_t ts_small_parse_table[] = {
       sym_sleep_action,
       sym_action,
       sym_string,
-  [1429] = 9,
+  [2117] = 12,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE,
-    ACTIONS(19), 1,
-      anon_sym_LT,
-    ACTIONS(21), 1,
-      anon_sym_LBRACK,
-    ACTIONS(23), 1,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
       anon_sym_LPAREN,
-    STATE(26), 1,
-      aux_sym_seq_repeat1,
-    ACTIONS(15), 2,
-      sym__simple_identifier,
-      aux_sym_word_token1,
-    ACTIONS(190), 5,
-      anon_sym_COLON,
-      anon_sym_PIPE,
-      sym_end_anchor,
-      anon_sym_RBRACK,
-      anon_sym_RPAREN,
-    STATE(64), 8,
-      sym__primary_rule,
-      sym_word,
-      sym_list,
-      sym_capture,
-      sym_optional,
-      sym_repeat,
-      sym_repeat1,
-      sym_parenthesized_rule,
-  [1469] = 9,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(197), 1,
-      anon_sym_LBRACE,
-    ACTIONS(200), 1,
-      anon_sym_LT,
-    ACTIONS(203), 1,
-      anon_sym_LBRACK,
-    ACTIONS(206), 1,
-      anon_sym_LPAREN,
-    STATE(26), 1,
-      aux_sym_seq_repeat1,
-    ACTIONS(192), 2,
-      sym__simple_identifier,
-      aux_sym_word_token1,
-    ACTIONS(195), 5,
-      anon_sym_COLON,
-      anon_sym_PIPE,
-      sym_end_anchor,
-      anon_sym_RBRACK,
-      anon_sym_RPAREN,
-    STATE(64), 8,
-      sym__primary_rule,
-      sym_word,
-      sym_list,
-      sym_capture,
-      sym_optional,
-      sym_repeat,
-      sym_repeat1,
-      sym_parenthesized_rule,
-  [1509] = 11,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(13), 1,
-      sym_start_anchor,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE,
-    ACTIONS(19), 1,
-      anon_sym_LT,
-    ACTIONS(21), 1,
-      anon_sym_LBRACK,
-    ACTIONS(23), 1,
-      anon_sym_LPAREN,
-    STATE(140), 1,
-      sym__optional_anchor,
-    ACTIONS(15), 2,
-      sym__simple_identifier,
-      aux_sym_word_token1,
-    STATE(134), 2,
-      sym__optional_seq,
-      sym_seq,
-    STATE(167), 2,
-      sym__optional_choice,
-      sym_choice,
-    STATE(18), 8,
-      sym__primary_rule,
-      sym_word,
-      sym_list,
-      sym_capture,
-      sym_optional,
-      sym_repeat,
-      sym_repeat1,
-      sym_parenthesized_rule,
-  [1553] = 13,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(41), 1,
+    ACTIONS(106), 1,
       anon_sym_key_LPAREN,
     ACTIONS(108), 1,
-      sym_integer,
-    ACTIONS(110), 1,
-      sym__string_start,
-    ACTIONS(168), 1,
-      anon_sym_DASH,
-    ACTIONS(170), 1,
-      anon_sym_LPAREN,
-    ACTIONS(174), 1,
       anon_sym_sleep_LPAREN,
-    ACTIONS(178), 1,
-      sym_float,
-    ACTIONS(209), 1,
-      anon_sym_RPAREN,
-    STATE(80), 1,
-      sym_identifier,
-    STATE(108), 1,
-      sym_expression,
-    ACTIONS(43), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(102), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [1601] = 12,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(41), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(108), 1,
-      sym_integer,
     ACTIONS(110), 1,
-      sym__string_start,
-    ACTIONS(168), 1,
-      anon_sym_DASH,
-    ACTIONS(170), 1,
-      anon_sym_LPAREN,
-    ACTIONS(174), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(178), 1,
+      sym_integer,
+    ACTIONS(112), 1,
       sym_float,
-    STATE(80), 1,
-      sym_identifier,
-    STATE(93), 1,
-      sym_expression,
-    ACTIONS(43), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(102), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [1646] = 12,
-    ACTIONS(3), 1,
-      sym_comment,
     ACTIONS(116), 1,
-      anon_sym_DASH,
-    ACTIONS(118), 1,
-      anon_sym_LPAREN,
-    ACTIONS(120), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
-      sym_integer,
-    ACTIONS(126), 1,
-      sym_float,
-    ACTIONS(130), 1,
       sym__string_start,
-    STATE(105), 1,
+    STATE(116), 1,
+      sym_identifier,
+    STATE(136), 1,
+      sym_expression,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [2162] = 12,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
+    ACTIONS(116), 1,
+      sym__string_start,
+    STATE(116), 1,
+      sym_identifier,
+    STATE(127), 1,
+      sym_expression,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [2207] = 12,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(41), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(170), 1,
+      sym_integer,
+    ACTIONS(172), 1,
+      sym__string_start,
+    ACTIONS(182), 1,
+      anon_sym_DASH,
+    ACTIONS(184), 1,
+      anon_sym_LPAREN,
+    ACTIONS(188), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(192), 1,
+      sym_float,
+    STATE(90), 1,
       sym_identifier,
     STATE(132), 1,
       sym_expression,
-    ACTIONS(114), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(112), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [1691] = 12,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(41), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(108), 1,
-      sym_integer,
-    ACTIONS(110), 1,
-      sym__string_start,
-    ACTIONS(168), 1,
-      anon_sym_DASH,
-    ACTIONS(170), 1,
-      anon_sym_LPAREN,
-    ACTIONS(174), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(178), 1,
-      sym_float,
-    STATE(80), 1,
-      sym_identifier,
-    STATE(92), 1,
-      sym_expression,
     ACTIONS(43), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    STATE(102), 8,
+    STATE(100), 8,
       sym_variable,
       sym_parenthesized_expression,
       sym_binary_operator,
@@ -4834,64 +5404,31 @@ static const uint16_t ts_small_parse_table[] = {
       sym_sleep_action,
       sym_action,
       sym_string,
-  [1736] = 12,
+  [2252] = 12,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(41), 1,
       anon_sym_key_LPAREN,
-    ACTIONS(108), 1,
-      sym_integer,
-    ACTIONS(110), 1,
-      sym__string_start,
-    ACTIONS(168), 1,
-      anon_sym_DASH,
     ACTIONS(170), 1,
-      anon_sym_LPAREN,
-    ACTIONS(174), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(178), 1,
-      sym_float,
-    STATE(80), 1,
-      sym_identifier,
-    STATE(126), 1,
-      sym_expression,
-    ACTIONS(43), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(102), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [1781] = 12,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(41), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(108), 1,
       sym_integer,
-    ACTIONS(110), 1,
+    ACTIONS(172), 1,
       sym__string_start,
-    ACTIONS(168), 1,
+    ACTIONS(182), 1,
       anon_sym_DASH,
-    ACTIONS(170), 1,
+    ACTIONS(184), 1,
       anon_sym_LPAREN,
-    ACTIONS(174), 1,
+    ACTIONS(188), 1,
       anon_sym_sleep_LPAREN,
-    ACTIONS(178), 1,
+    ACTIONS(192), 1,
       sym_float,
-    STATE(80), 1,
-      sym_identifier,
     STATE(90), 1,
+      sym_identifier,
+    STATE(129), 1,
       sym_expression,
     ACTIONS(43), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    STATE(102), 8,
+    STATE(100), 8,
       sym_variable,
       sym_parenthesized_expression,
       sym_binary_operator,
@@ -4900,64 +5437,31 @@ static const uint16_t ts_small_parse_table[] = {
       sym_sleep_action,
       sym_action,
       sym_string,
-  [1826] = 12,
+  [2297] = 12,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(41), 1,
       anon_sym_key_LPAREN,
-    ACTIONS(108), 1,
-      sym_integer,
-    ACTIONS(110), 1,
-      sym__string_start,
-    ACTIONS(168), 1,
-      anon_sym_DASH,
     ACTIONS(170), 1,
-      anon_sym_LPAREN,
-    ACTIONS(174), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(178), 1,
-      sym_float,
-    STATE(80), 1,
-      sym_identifier,
-    STATE(113), 1,
-      sym_expression,
-    ACTIONS(43), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(102), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [1871] = 12,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(116), 1,
-      anon_sym_DASH,
-    ACTIONS(118), 1,
-      anon_sym_LPAREN,
-    ACTIONS(120), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
       sym_integer,
-    ACTIONS(126), 1,
-      sym_float,
-    ACTIONS(130), 1,
+    ACTIONS(172), 1,
       sym__string_start,
-    STATE(105), 1,
+    ACTIONS(182), 1,
+      anon_sym_DASH,
+    ACTIONS(184), 1,
+      anon_sym_LPAREN,
+    ACTIONS(188), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(192), 1,
+      sym_float,
+    STATE(90), 1,
       sym_identifier,
     STATE(130), 1,
       sym_expression,
-    ACTIONS(114), 2,
+    ACTIONS(43), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    STATE(112), 8,
+    STATE(100), 8,
       sym_variable,
       sym_parenthesized_expression,
       sym_binary_operator,
@@ -4966,31 +5470,31 @@ static const uint16_t ts_small_parse_table[] = {
       sym_sleep_action,
       sym_action,
       sym_string,
-  [1916] = 12,
+  [2342] = 12,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(116), 1,
-      anon_sym_DASH,
-    ACTIONS(118), 1,
-      anon_sym_LPAREN,
-    ACTIONS(120), 1,
+    ACTIONS(41), 1,
       anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
+    ACTIONS(170), 1,
       sym_integer,
-    ACTIONS(126), 1,
-      sym_float,
-    ACTIONS(130), 1,
+    ACTIONS(172), 1,
       sym__string_start,
-    STATE(105), 1,
+    ACTIONS(182), 1,
+      anon_sym_DASH,
+    ACTIONS(184), 1,
+      anon_sym_LPAREN,
+    ACTIONS(188), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(192), 1,
+      sym_float,
+    STATE(90), 1,
       sym_identifier,
-    STATE(123), 1,
+    STATE(112), 1,
       sym_expression,
-    ACTIONS(114), 2,
+    ACTIONS(43), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    STATE(112), 8,
+    STATE(100), 8,
       sym_variable,
       sym_parenthesized_expression,
       sym_binary_operator,
@@ -4999,31 +5503,130 @@ static const uint16_t ts_small_parse_table[] = {
       sym_sleep_action,
       sym_action,
       sym_string,
-  [1961] = 12,
+  [2387] = 12,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(116), 1,
-      anon_sym_DASH,
-    ACTIONS(118), 1,
-      anon_sym_LPAREN,
-    ACTIONS(120), 1,
+    ACTIONS(41), 1,
       anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
+    ACTIONS(170), 1,
       sym_integer,
-    ACTIONS(126), 1,
-      sym_float,
-    ACTIONS(130), 1,
+    ACTIONS(172), 1,
       sym__string_start,
-    STATE(105), 1,
+    ACTIONS(182), 1,
+      anon_sym_DASH,
+    ACTIONS(184), 1,
+      anon_sym_LPAREN,
+    ACTIONS(188), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(192), 1,
+      sym_float,
+    STATE(90), 1,
+      sym_identifier,
+    STATE(145), 1,
+      sym_expression,
+    ACTIONS(43), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(100), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [2432] = 12,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
+    ACTIONS(116), 1,
+      sym__string_start,
+    STATE(116), 1,
+      sym_identifier,
+    STATE(147), 1,
+      sym_expression,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [2477] = 12,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
+    ACTIONS(116), 1,
+      sym__string_start,
+    STATE(116), 1,
+      sym_identifier,
+    STATE(148), 1,
+      sym_expression,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [2522] = 12,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
+    ACTIONS(116), 1,
+      sym__string_start,
+    STATE(116), 1,
       sym_identifier,
     STATE(128), 1,
       sym_expression,
-    ACTIONS(114), 2,
+    ACTIONS(96), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    STATE(112), 8,
+    STATE(143), 8,
       sym_variable,
       sym_parenthesized_expression,
       sym_binary_operator,
@@ -5032,31 +5635,31 @@ static const uint16_t ts_small_parse_table[] = {
       sym_sleep_action,
       sym_action,
       sym_string,
-  [2006] = 12,
+  [2567] = 12,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(41), 1,
       anon_sym_key_LPAREN,
-    ACTIONS(108), 1,
-      sym_integer,
-    ACTIONS(110), 1,
-      sym__string_start,
-    ACTIONS(168), 1,
-      anon_sym_DASH,
     ACTIONS(170), 1,
+      sym_integer,
+    ACTIONS(172), 1,
+      sym__string_start,
+    ACTIONS(182), 1,
+      anon_sym_DASH,
+    ACTIONS(184), 1,
       anon_sym_LPAREN,
-    ACTIONS(174), 1,
+    ACTIONS(188), 1,
       anon_sym_sleep_LPAREN,
-    ACTIONS(178), 1,
+    ACTIONS(192), 1,
       sym_float,
-    STATE(80), 1,
+    STATE(90), 1,
       sym_identifier,
-    STATE(100), 1,
+    STATE(133), 1,
       sym_expression,
     ACTIONS(43), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    STATE(102), 8,
+    STATE(100), 8,
       sym_variable,
       sym_parenthesized_expression,
       sym_binary_operator,
@@ -5065,31 +5668,64 @@ static const uint16_t ts_small_parse_table[] = {
       sym_sleep_action,
       sym_action,
       sym_string,
-  [2051] = 12,
+  [2612] = 12,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(98), 1,
+      anon_sym_DASH,
+    ACTIONS(100), 1,
+      anon_sym_LPAREN,
+    ACTIONS(106), 1,
+      anon_sym_key_LPAREN,
+    ACTIONS(108), 1,
+      anon_sym_sleep_LPAREN,
+    ACTIONS(110), 1,
+      sym_integer,
+    ACTIONS(112), 1,
+      sym_float,
+    ACTIONS(116), 1,
+      sym__string_start,
+    STATE(116), 1,
+      sym_identifier,
+    STATE(131), 1,
+      sym_expression,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(143), 8,
+      sym_variable,
+      sym_parenthesized_expression,
+      sym_binary_operator,
+      sym_unary_operator,
+      sym_key_action,
+      sym_sleep_action,
+      sym_action,
+      sym_string,
+  [2657] = 12,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(41), 1,
       anon_sym_key_LPAREN,
-    ACTIONS(108), 1,
-      sym_integer,
-    ACTIONS(110), 1,
-      sym__string_start,
-    ACTIONS(168), 1,
-      anon_sym_DASH,
     ACTIONS(170), 1,
+      sym_integer,
+    ACTIONS(172), 1,
+      sym__string_start,
+    ACTIONS(182), 1,
+      anon_sym_DASH,
+    ACTIONS(184), 1,
       anon_sym_LPAREN,
-    ACTIONS(174), 1,
+    ACTIONS(188), 1,
       anon_sym_sleep_LPAREN,
-    ACTIONS(178), 1,
+    ACTIONS(192), 1,
       sym_float,
-    STATE(80), 1,
+    STATE(90), 1,
       sym_identifier,
-    STATE(108), 1,
+    STATE(122), 1,
       sym_expression,
     ACTIONS(43), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    STATE(102), 8,
+    STATE(100), 8,
       sym_variable,
       sym_parenthesized_expression,
       sym_binary_operator,
@@ -5098,73 +5734,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_sleep_action,
       sym_action,
       sym_string,
-  [2096] = 12,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(116), 1,
-      anon_sym_DASH,
-    ACTIONS(118), 1,
-      anon_sym_LPAREN,
-    ACTIONS(120), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
-      sym_integer,
-    ACTIONS(126), 1,
-      sym_float,
-    ACTIONS(130), 1,
-      sym__string_start,
-    STATE(105), 1,
-      sym_identifier,
-    STATE(119), 1,
-      sym_expression,
-    ACTIONS(114), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(112), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [2141] = 12,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(116), 1,
-      anon_sym_DASH,
-    ACTIONS(118), 1,
-      anon_sym_LPAREN,
-    ACTIONS(120), 1,
-      anon_sym_key_LPAREN,
-    ACTIONS(122), 1,
-      anon_sym_sleep_LPAREN,
-    ACTIONS(124), 1,
-      sym_integer,
-    ACTIONS(126), 1,
-      sym_float,
-    ACTIONS(130), 1,
-      sym__string_start,
-    STATE(105), 1,
-      sym_identifier,
-    STATE(125), 1,
-      sym_expression,
-    ACTIONS(114), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(112), 8,
-      sym_variable,
-      sym_parenthesized_expression,
-      sym_binary_operator,
-      sym_unary_operator,
-      sym_key_action,
-      sym_sleep_action,
-      sym_action,
-      sym_string,
-  [2186] = 10,
+  [2702] = 10,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(13), 1,
@@ -5177,15 +5747,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACK,
     ACTIONS(23), 1,
       anon_sym_LPAREN,
-    STATE(144), 1,
+    STATE(159), 1,
       sym__optional_anchor,
     ACTIONS(15), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    STATE(134), 2,
+    STATE(150), 2,
       sym__optional_seq,
       sym_seq,
-    STATE(18), 8,
+    STATE(22), 8,
       sym__primary_rule,
       sym_word,
       sym_list,
@@ -5194,13 +5764,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_repeat,
       sym_repeat1,
       sym_parenthesized_rule,
-  [2226] = 3,
+  [2742] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(213), 2,
+    ACTIONS(227), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(211), 15,
+    ACTIONS(225), 15,
       ts_builtin_sym_end,
       sym_start_anchor,
       anon_sym_LBRACE,
@@ -5216,13 +5786,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_settings_binding,
       sym_tag_binding,
       anon_sym_key_LPAREN,
-  [2251] = 3,
+  [2767] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(217), 2,
+    ACTIONS(231), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(215), 15,
+    ACTIONS(229), 15,
       ts_builtin_sym_end,
       sym_start_anchor,
       anon_sym_LBRACE,
@@ -5238,13 +5808,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_settings_binding,
       sym_tag_binding,
       anon_sym_key_LPAREN,
-  [2276] = 3,
+  [2792] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(221), 2,
+    ACTIONS(235), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(219), 15,
+    ACTIONS(233), 15,
       ts_builtin_sym_end,
       sym_start_anchor,
       anon_sym_LBRACE,
@@ -5260,13 +5830,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_settings_binding,
       sym_tag_binding,
       anon_sym_key_LPAREN,
-  [2301] = 3,
+  [2817] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(225), 2,
+    ACTIONS(239), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(223), 15,
+    ACTIONS(237), 15,
       ts_builtin_sym_end,
       sym_start_anchor,
       anon_sym_LBRACE,
@@ -5282,13 +5852,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_settings_binding,
       sym_tag_binding,
       anon_sym_key_LPAREN,
-  [2326] = 3,
+  [2842] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(229), 2,
+    ACTIONS(243), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(227), 15,
+    ACTIONS(241), 15,
       ts_builtin_sym_end,
       sym_start_anchor,
       anon_sym_LBRACE,
@@ -5304,13 +5874,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_settings_binding,
       sym_tag_binding,
       anon_sym_key_LPAREN,
-  [2351] = 3,
+  [2867] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(233), 2,
+    ACTIONS(247), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(231), 15,
+    ACTIONS(245), 15,
       ts_builtin_sym_end,
       sym_start_anchor,
       anon_sym_LBRACE,
@@ -5326,13 +5896,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_settings_binding,
       sym_tag_binding,
       anon_sym_key_LPAREN,
-  [2376] = 3,
+  [2892] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(237), 2,
+    ACTIONS(251), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(235), 15,
+    ACTIONS(249), 15,
       ts_builtin_sym_end,
       sym_start_anchor,
       anon_sym_LBRACE,
@@ -5348,13 +5918,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_settings_binding,
       sym_tag_binding,
       anon_sym_key_LPAREN,
-  [2401] = 3,
+  [2917] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(241), 2,
+    ACTIONS(255), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(239), 15,
+    ACTIONS(253), 15,
       ts_builtin_sym_end,
       sym_start_anchor,
       anon_sym_LBRACE,
@@ -5370,13 +5940,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_settings_binding,
       sym_tag_binding,
       anon_sym_key_LPAREN,
-  [2426] = 3,
+  [2942] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(245), 2,
+    ACTIONS(259), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(243), 15,
+    ACTIONS(257), 15,
       ts_builtin_sym_end,
       sym_start_anchor,
       anon_sym_LBRACE,
@@ -5392,13 +5962,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_settings_binding,
       sym_tag_binding,
       anon_sym_key_LPAREN,
-  [2451] = 3,
+  [2967] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(249), 2,
+    ACTIONS(263), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(247), 15,
+    ACTIONS(261), 15,
       ts_builtin_sym_end,
       sym_start_anchor,
       anon_sym_LBRACE,
@@ -5414,13 +5984,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_settings_binding,
       sym_tag_binding,
       anon_sym_key_LPAREN,
-  [2476] = 3,
+  [2992] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(253), 2,
+    ACTIONS(267), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(251), 15,
+    ACTIONS(265), 15,
       ts_builtin_sym_end,
       sym_start_anchor,
       anon_sym_LBRACE,
@@ -5436,13 +6006,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_settings_binding,
       sym_tag_binding,
       anon_sym_key_LPAREN,
-  [2501] = 3,
+  [3017] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(257), 2,
+    ACTIONS(271), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(255), 15,
+    ACTIONS(269), 15,
       ts_builtin_sym_end,
       sym_start_anchor,
       anon_sym_LBRACE,
@@ -5458,13 +6028,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_settings_binding,
       sym_tag_binding,
       anon_sym_key_LPAREN,
-  [2526] = 3,
+  [3042] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(261), 2,
+    ACTIONS(275), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(259), 15,
+    ACTIONS(273), 15,
       ts_builtin_sym_end,
       sym_start_anchor,
       anon_sym_LBRACE,
@@ -5480,13 +6050,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_settings_binding,
       sym_tag_binding,
       anon_sym_key_LPAREN,
-  [2551] = 3,
+  [3067] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(265), 2,
+    ACTIONS(279), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(263), 15,
+    ACTIONS(277), 15,
       ts_builtin_sym_end,
       sym_start_anchor,
       anon_sym_LBRACE,
@@ -5502,13 +6072,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_settings_binding,
       sym_tag_binding,
       anon_sym_key_LPAREN,
-  [2576] = 3,
+  [3092] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(269), 2,
+    ACTIONS(283), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(267), 15,
+    ACTIONS(281), 15,
       ts_builtin_sym_end,
       sym_start_anchor,
       anon_sym_LBRACE,
@@ -5524,13 +6094,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_settings_binding,
       sym_tag_binding,
       anon_sym_key_LPAREN,
-  [2601] = 3,
+  [3117] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(273), 2,
+    ACTIONS(287), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(271), 15,
+    ACTIONS(285), 15,
       ts_builtin_sym_end,
       sym_start_anchor,
       anon_sym_LBRACE,
@@ -5546,255 +6116,171 @@ static const uint16_t ts_small_parse_table[] = {
       sym_settings_binding,
       sym_tag_binding,
       anon_sym_key_LPAREN,
-  [2626] = 3,
+  [3142] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(277), 2,
-      sym__simple_identifier,
-      aux_sym_word_token1,
-    ACTIONS(275), 15,
-      ts_builtin_sym_end,
-      sym_start_anchor,
-      anon_sym_LBRACE,
-      anon_sym_LT,
-      anon_sym_LBRACK,
-      anon_sym_LPAREN,
-      anon_sym_app_LPAREN,
-      anon_sym_face_LPAREN,
-      anon_sym_deck_LPAREN,
-      anon_sym_gamepad_LPAREN,
-      anon_sym_noise_LPAREN,
-      anon_sym_parrot_LPAREN,
-      sym_settings_binding,
-      sym_tag_binding,
-      anon_sym_key_LPAREN,
-  [2651] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(281), 2,
-      sym__simple_identifier,
-      aux_sym_word_token1,
-    ACTIONS(279), 15,
-      ts_builtin_sym_end,
-      sym_start_anchor,
-      anon_sym_LBRACE,
-      anon_sym_LT,
-      anon_sym_LBRACK,
-      anon_sym_LPAREN,
-      anon_sym_app_LPAREN,
-      anon_sym_face_LPAREN,
-      anon_sym_deck_LPAREN,
-      anon_sym_gamepad_LPAREN,
-      anon_sym_noise_LPAREN,
-      anon_sym_parrot_LPAREN,
-      sym_settings_binding,
-      sym_tag_binding,
-      anon_sym_key_LPAREN,
-  [2676] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(285), 2,
-      sym__simple_identifier,
-      aux_sym_word_token1,
-    ACTIONS(283), 15,
-      ts_builtin_sym_end,
-      sym_start_anchor,
-      anon_sym_LBRACE,
-      anon_sym_LT,
-      anon_sym_LBRACK,
-      anon_sym_LPAREN,
-      anon_sym_app_LPAREN,
-      anon_sym_face_LPAREN,
-      anon_sym_deck_LPAREN,
-      anon_sym_gamepad_LPAREN,
-      anon_sym_noise_LPAREN,
-      anon_sym_parrot_LPAREN,
-      sym_settings_binding,
-      sym_tag_binding,
-      anon_sym_key_LPAREN,
-  [2701] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(289), 2,
-      sym__simple_identifier,
-      aux_sym_word_token1,
-    ACTIONS(287), 15,
-      ts_builtin_sym_end,
-      sym_start_anchor,
-      anon_sym_LBRACE,
-      anon_sym_LT,
-      anon_sym_LBRACK,
-      anon_sym_LPAREN,
-      anon_sym_app_LPAREN,
-      anon_sym_face_LPAREN,
-      anon_sym_deck_LPAREN,
-      anon_sym_gamepad_LPAREN,
-      anon_sym_noise_LPAREN,
-      anon_sym_parrot_LPAREN,
-      sym_settings_binding,
-      sym_tag_binding,
-      anon_sym_key_LPAREN,
-  [2726] = 8,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE,
-    ACTIONS(19), 1,
-      anon_sym_LT,
-    ACTIONS(21), 1,
-      anon_sym_LBRACK,
-    ACTIONS(23), 1,
-      anon_sym_LPAREN,
-    ACTIONS(15), 2,
-      sym__simple_identifier,
-      aux_sym_word_token1,
-    STATE(139), 2,
-      sym__optional_seq,
-      sym_seq,
-    STATE(18), 8,
-      sym__primary_rule,
-      sym_word,
-      sym_list,
-      sym_capture,
-      sym_optional,
-      sym_repeat,
-      sym_repeat1,
-      sym_parenthesized_rule,
-  [2760] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(164), 1,
-      anon_sym_STAR,
-    ACTIONS(166), 1,
-      anon_sym_PLUS,
     ACTIONS(291), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(293), 9,
-      anon_sym_COLON,
-      anon_sym_PIPE,
-      sym_end_anchor,
+    ACTIONS(289), 15,
+      ts_builtin_sym_end,
+      sym_start_anchor,
       anon_sym_LBRACE,
       anon_sym_LT,
       anon_sym_LBRACK,
-      anon_sym_RBRACK,
       anon_sym_LPAREN,
-      anon_sym_RPAREN,
-  [2785] = 3,
+      anon_sym_app_LPAREN,
+      anon_sym_face_LPAREN,
+      anon_sym_deck_LPAREN,
+      anon_sym_gamepad_LPAREN,
+      anon_sym_noise_LPAREN,
+      anon_sym_parrot_LPAREN,
+      sym_settings_binding,
+      sym_tag_binding,
+      anon_sym_key_LPAREN,
+  [3167] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(295), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(297), 11,
-      anon_sym_COLON,
-      anon_sym_PIPE,
-      sym_end_anchor,
+    ACTIONS(293), 15,
+      ts_builtin_sym_end,
+      sym_start_anchor,
       anon_sym_LBRACE,
       anon_sym_LT,
       anon_sym_LBRACK,
-      anon_sym_RBRACK,
-      anon_sym_STAR,
-      anon_sym_PLUS,
       anon_sym_LPAREN,
-      anon_sym_RPAREN,
-  [2806] = 3,
+      anon_sym_app_LPAREN,
+      anon_sym_face_LPAREN,
+      anon_sym_deck_LPAREN,
+      anon_sym_gamepad_LPAREN,
+      anon_sym_noise_LPAREN,
+      anon_sym_parrot_LPAREN,
+      sym_settings_binding,
+      sym_tag_binding,
+      anon_sym_key_LPAREN,
+  [3192] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(299), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(301), 11,
-      anon_sym_COLON,
-      anon_sym_PIPE,
-      sym_end_anchor,
+    ACTIONS(297), 15,
+      ts_builtin_sym_end,
+      sym_start_anchor,
       anon_sym_LBRACE,
       anon_sym_LT,
       anon_sym_LBRACK,
-      anon_sym_RBRACK,
-      anon_sym_STAR,
-      anon_sym_PLUS,
       anon_sym_LPAREN,
-      anon_sym_RPAREN,
-  [2827] = 3,
+      anon_sym_app_LPAREN,
+      anon_sym_face_LPAREN,
+      anon_sym_deck_LPAREN,
+      anon_sym_gamepad_LPAREN,
+      anon_sym_noise_LPAREN,
+      anon_sym_parrot_LPAREN,
+      sym_settings_binding,
+      sym_tag_binding,
+      anon_sym_key_LPAREN,
+  [3217] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(303), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(305), 11,
-      anon_sym_COLON,
-      anon_sym_PIPE,
-      sym_end_anchor,
+    ACTIONS(301), 15,
+      ts_builtin_sym_end,
+      sym_start_anchor,
       anon_sym_LBRACE,
       anon_sym_LT,
       anon_sym_LBRACK,
-      anon_sym_RBRACK,
-      anon_sym_STAR,
-      anon_sym_PLUS,
       anon_sym_LPAREN,
-      anon_sym_RPAREN,
-  [2848] = 3,
+      anon_sym_app_LPAREN,
+      anon_sym_face_LPAREN,
+      anon_sym_deck_LPAREN,
+      anon_sym_gamepad_LPAREN,
+      anon_sym_noise_LPAREN,
+      anon_sym_parrot_LPAREN,
+      sym_settings_binding,
+      sym_tag_binding,
+      anon_sym_key_LPAREN,
+  [3242] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(307), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(309), 11,
-      anon_sym_COLON,
-      anon_sym_PIPE,
-      sym_end_anchor,
+    ACTIONS(305), 15,
+      ts_builtin_sym_end,
+      sym_start_anchor,
       anon_sym_LBRACE,
       anon_sym_LT,
       anon_sym_LBRACK,
-      anon_sym_RBRACK,
-      anon_sym_STAR,
-      anon_sym_PLUS,
       anon_sym_LPAREN,
-      anon_sym_RPAREN,
-  [2869] = 3,
+      anon_sym_app_LPAREN,
+      anon_sym_face_LPAREN,
+      anon_sym_deck_LPAREN,
+      anon_sym_gamepad_LPAREN,
+      anon_sym_noise_LPAREN,
+      anon_sym_parrot_LPAREN,
+      sym_settings_binding,
+      sym_tag_binding,
+      anon_sym_key_LPAREN,
+  [3267] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(311), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(313), 11,
-      anon_sym_COLON,
-      anon_sym_PIPE,
-      sym_end_anchor,
+    ACTIONS(309), 15,
+      ts_builtin_sym_end,
+      sym_start_anchor,
       anon_sym_LBRACE,
       anon_sym_LT,
       anon_sym_LBRACK,
-      anon_sym_RBRACK,
-      anon_sym_STAR,
-      anon_sym_PLUS,
       anon_sym_LPAREN,
-      anon_sym_RPAREN,
-  [2890] = 3,
+      anon_sym_app_LPAREN,
+      anon_sym_face_LPAREN,
+      anon_sym_deck_LPAREN,
+      anon_sym_gamepad_LPAREN,
+      anon_sym_noise_LPAREN,
+      anon_sym_parrot_LPAREN,
+      sym_settings_binding,
+      sym_tag_binding,
+      anon_sym_key_LPAREN,
+  [3292] = 8,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(315), 2,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE,
+    ACTIONS(19), 1,
+      anon_sym_LT,
+    ACTIONS(21), 1,
+      anon_sym_LBRACK,
+    ACTIONS(23), 1,
+      anon_sym_LPAREN,
+    ACTIONS(15), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(317), 11,
-      anon_sym_COLON,
-      anon_sym_PIPE,
-      sym_end_anchor,
-      anon_sym_LBRACE,
-      anon_sym_LT,
-      anon_sym_LBRACK,
-      anon_sym_RBRACK,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_LPAREN,
-      anon_sym_RPAREN,
-  [2911] = 3,
+    STATE(154), 2,
+      sym__optional_seq,
+      sym_seq,
+    STATE(22), 8,
+      sym__primary_rule,
+      sym_word,
+      sym_list,
+      sym_capture,
+      sym_optional,
+      sym_repeat,
+      sym_repeat1,
+      sym_parenthesized_rule,
+  [3326] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(319), 2,
+    ACTIONS(313), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(321), 11,
+    ACTIONS(315), 11,
       anon_sym_COLON,
       anon_sym_PIPE,
       sym_end_anchor,
@@ -5806,98 +6292,46 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PLUS,
       anon_sym_LPAREN,
       anon_sym_RPAREN,
-  [2932] = 8,
-    ACTIONS(96), 1,
-      sym_comment,
-    ACTIONS(323), 1,
-      anon_sym_LBRACE,
-    ACTIONS(325), 1,
-      anon_sym_RBRACE,
-    ACTIONS(331), 1,
-      sym_string_content,
-    ACTIONS(333), 1,
-      sym__string_end,
-    ACTIONS(327), 2,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_RBRACE_RBRACE,
-    ACTIONS(329), 2,
-      sym_string_escape_sequence,
-      sym__not_escapesequence,
-    STATE(73), 4,
-      sym_interpolation,
-      sym__escape_interpolation,
-      sym__not_interpolation,
-      aux_sym_string_repeat1,
-  [2962] = 8,
-    ACTIONS(96), 1,
-      sym_comment,
-    ACTIONS(335), 1,
-      anon_sym_LBRACE,
-    ACTIONS(338), 1,
-      anon_sym_RBRACE,
-    ACTIONS(347), 1,
-      sym_string_content,
-    ACTIONS(350), 1,
-      sym__string_end,
-    ACTIONS(341), 2,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_RBRACE_RBRACE,
-    ACTIONS(344), 2,
-      sym_string_escape_sequence,
-      sym__not_escapesequence,
-    STATE(73), 4,
-      sym_interpolation,
-      sym__escape_interpolation,
-      sym__not_interpolation,
-      aux_sym_string_repeat1,
-  [2992] = 8,
-    ACTIONS(96), 1,
-      sym_comment,
-    ACTIONS(323), 1,
-      anon_sym_LBRACE,
-    ACTIONS(325), 1,
-      anon_sym_RBRACE,
-    ACTIONS(331), 1,
-      sym_string_content,
-    ACTIONS(352), 1,
-      sym__string_end,
-    ACTIONS(327), 2,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_RBRACE_RBRACE,
-    ACTIONS(329), 2,
-      sym_string_escape_sequence,
-      sym__not_escapesequence,
-    STATE(73), 4,
-      sym_interpolation,
-      sym__escape_interpolation,
-      sym__not_interpolation,
-      aux_sym_string_repeat1,
-  [3022] = 8,
-    ACTIONS(96), 1,
-      sym_comment,
-    ACTIONS(323), 1,
-      anon_sym_LBRACE,
-    ACTIONS(325), 1,
-      anon_sym_RBRACE,
-    ACTIONS(356), 1,
-      sym_string_content,
-    ACTIONS(358), 1,
-      sym__string_end,
-    ACTIONS(327), 2,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_RBRACE_RBRACE,
-    ACTIONS(354), 2,
-      sym_string_escape_sequence,
-      sym__not_escapesequence,
-    STATE(74), 4,
-      sym_interpolation,
-      sym__escape_interpolation,
-      sym__not_interpolation,
-      aux_sym_string_repeat1,
-  [3052] = 2,
+  [3347] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(360), 12,
+    ACTIONS(317), 2,
+      sym__simple_identifier,
+      aux_sym_word_token1,
+    ACTIONS(319), 11,
+      anon_sym_COLON,
+      anon_sym_PIPE,
+      sym_end_anchor,
+      anon_sym_LBRACE,
+      anon_sym_LT,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+  [3368] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(321), 2,
+      sym__simple_identifier,
+      aux_sym_word_token1,
+    ACTIONS(323), 11,
+      anon_sym_COLON,
+      anon_sym_PIPE,
+      sym_end_anchor,
+      anon_sym_LBRACE,
+      anon_sym_LT,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+  [3389] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(325), 13,
       anon_sym_DASH,
       anon_sym_COLON,
       anon_sym_RBRACE,
@@ -5905,42 +6339,326 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       anon_sym_PLUS,
       anon_sym_RPAREN,
+      anon_sym_in,
       anon_sym_SLASH,
       anon_sym_PERCENT,
       anon_sym_or,
       anon_sym_LPAREN2,
       anon_sym_COMMA,
-  [3070] = 8,
-    ACTIONS(96), 1,
+  [3408] = 5,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(323), 1,
-      anon_sym_LBRACE,
-    ACTIONS(325), 1,
-      anon_sym_RBRACE,
-    ACTIONS(364), 1,
-      sym_string_content,
-    ACTIONS(366), 1,
-      sym__string_end,
+    ACTIONS(178), 1,
+      anon_sym_STAR,
+    ACTIONS(180), 1,
+      anon_sym_PLUS,
     ACTIONS(327), 2,
+      sym__simple_identifier,
+      aux_sym_word_token1,
+    ACTIONS(329), 9,
+      anon_sym_COLON,
+      anon_sym_PIPE,
+      sym_end_anchor,
+      anon_sym_LBRACE,
+      anon_sym_LT,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+  [3433] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(331), 2,
+      sym__simple_identifier,
+      aux_sym_word_token1,
+    ACTIONS(333), 11,
+      anon_sym_COLON,
+      anon_sym_PIPE,
+      sym_end_anchor,
+      anon_sym_LBRACE,
+      anon_sym_LT,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+  [3454] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(335), 2,
+      sym__simple_identifier,
+      aux_sym_word_token1,
+    ACTIONS(337), 11,
+      anon_sym_COLON,
+      anon_sym_PIPE,
+      sym_end_anchor,
+      anon_sym_LBRACE,
+      anon_sym_LT,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+  [3475] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(339), 2,
+      sym__simple_identifier,
+      aux_sym_word_token1,
+    ACTIONS(341), 11,
+      anon_sym_COLON,
+      anon_sym_PIPE,
+      sym_end_anchor,
+      anon_sym_LBRACE,
+      anon_sym_LT,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+  [3496] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(343), 2,
+      sym__simple_identifier,
+      aux_sym_word_token1,
+    ACTIONS(345), 11,
+      anon_sym_COLON,
+      anon_sym_PIPE,
+      sym_end_anchor,
+      anon_sym_LBRACE,
+      anon_sym_LT,
+      anon_sym_LBRACK,
+      anon_sym_RBRACK,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_LPAREN,
+      anon_sym_RPAREN,
+  [3517] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(299), 5,
+      sym__simple_identifier,
+      anon_sym_if,
+      anon_sym_for,
+      aux_sym_identifier_token1,
+      sym_integer,
+    ACTIONS(297), 7,
+      sym__dedent,
+      sym__string_start,
+      anon_sym_DASH,
+      anon_sym_LPAREN,
+      anon_sym_key_LPAREN,
+      anon_sym_sleep_LPAREN,
+      sym_float,
+  [3537] = 8,
+    ACTIONS(158), 1,
+      sym_comment,
+    ACTIONS(347), 1,
+      anon_sym_LBRACE,
+    ACTIONS(349), 1,
+      anon_sym_RBRACE,
+    ACTIONS(355), 1,
+      sym_string_content,
+    ACTIONS(357), 1,
+      sym__string_end,
+    ACTIONS(351), 2,
       anon_sym_LBRACE_LBRACE,
       anon_sym_RBRACE_RBRACE,
-    ACTIONS(362), 2,
+    ACTIONS(353), 2,
       sym_string_escape_sequence,
       sym__not_escapesequence,
-    STATE(72), 4,
+    STATE(87), 4,
       sym_interpolation,
       sym__escape_interpolation,
       sym__not_interpolation,
       aux_sym_string_repeat1,
-  [3100] = 4,
+  [3567] = 8,
+    ACTIONS(158), 1,
+      sym_comment,
+    ACTIONS(347), 1,
+      anon_sym_LBRACE,
+    ACTIONS(349), 1,
+      anon_sym_RBRACE,
+    ACTIONS(361), 1,
+      sym_string_content,
+    ACTIONS(363), 1,
+      sym__string_end,
+    ACTIONS(351), 2,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_RBRACE_RBRACE,
+    ACTIONS(359), 2,
+      sym_string_escape_sequence,
+      sym__not_escapesequence,
+    STATE(88), 4,
+      sym_interpolation,
+      sym__escape_interpolation,
+      sym__not_interpolation,
+      aux_sym_string_repeat1,
+  [3597] = 8,
+    ACTIONS(158), 1,
+      sym_comment,
+    ACTIONS(365), 1,
+      anon_sym_LBRACE,
+    ACTIONS(368), 1,
+      anon_sym_RBRACE,
+    ACTIONS(377), 1,
+      sym_string_content,
+    ACTIONS(380), 1,
+      sym__string_end,
+    ACTIONS(371), 2,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_RBRACE_RBRACE,
+    ACTIONS(374), 2,
+      sym_string_escape_sequence,
+      sym__not_escapesequence,
+    STATE(86), 4,
+      sym_interpolation,
+      sym__escape_interpolation,
+      sym__not_interpolation,
+      aux_sym_string_repeat1,
+  [3627] = 8,
+    ACTIONS(158), 1,
+      sym_comment,
+    ACTIONS(347), 1,
+      anon_sym_LBRACE,
+    ACTIONS(349), 1,
+      anon_sym_RBRACE,
+    ACTIONS(384), 1,
+      sym_string_content,
+    ACTIONS(386), 1,
+      sym__string_end,
+    ACTIONS(351), 2,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_RBRACE_RBRACE,
+    ACTIONS(382), 2,
+      sym_string_escape_sequence,
+      sym__not_escapesequence,
+    STATE(86), 4,
+      sym_interpolation,
+      sym__escape_interpolation,
+      sym__not_interpolation,
+      aux_sym_string_repeat1,
+  [3657] = 8,
+    ACTIONS(158), 1,
+      sym_comment,
+    ACTIONS(347), 1,
+      anon_sym_LBRACE,
+    ACTIONS(349), 1,
+      anon_sym_RBRACE,
+    ACTIONS(384), 1,
+      sym_string_content,
+    ACTIONS(388), 1,
+      sym__string_end,
+    ACTIONS(351), 2,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_RBRACE_RBRACE,
+    ACTIONS(382), 2,
+      sym_string_escape_sequence,
+      sym__not_escapesequence,
+    STATE(86), 4,
+      sym_interpolation,
+      sym__escape_interpolation,
+      sym__not_interpolation,
+      aux_sym_string_repeat1,
+  [3687] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(368), 1,
+    ACTIONS(255), 5,
+      sym__simple_identifier,
+      anon_sym_if,
+      anon_sym_for,
+      aux_sym_identifier_token1,
+      sym_integer,
+    ACTIONS(253), 7,
+      sym__dedent,
+      sym__string_start,
+      anon_sym_DASH,
+      anon_sym_LPAREN,
+      anon_sym_key_LPAREN,
+      anon_sym_sleep_LPAREN,
+      sym_float,
+  [3707] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(392), 1,
+      anon_sym_LPAREN2,
+    STATE(108), 1,
+      sym_argument_list,
+    ACTIONS(390), 10,
+      anon_sym_DASH,
       anon_sym_COLON,
-    ACTIONS(319), 2,
+      anon_sym_RBRACE,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+      anon_sym_COMMA,
+  [3729] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(251), 5,
+      sym__simple_identifier,
+      anon_sym_if,
+      anon_sym_for,
+      aux_sym_identifier_token1,
+      sym_integer,
+    ACTIONS(249), 7,
+      sym__dedent,
+      sym__string_start,
+      anon_sym_DASH,
+      anon_sym_LPAREN,
+      anon_sym_key_LPAREN,
+      anon_sym_sleep_LPAREN,
+      sym_float,
+  [3749] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(259), 5,
+      sym__simple_identifier,
+      anon_sym_if,
+      anon_sym_for,
+      aux_sym_identifier_token1,
+      sym_integer,
+    ACTIONS(257), 7,
+      sym__dedent,
+      sym__string_start,
+      anon_sym_DASH,
+      anon_sym_LPAREN,
+      anon_sym_key_LPAREN,
+      anon_sym_sleep_LPAREN,
+      sym_float,
+  [3769] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(307), 5,
+      sym__simple_identifier,
+      anon_sym_if,
+      anon_sym_for,
+      aux_sym_identifier_token1,
+      sym_integer,
+    ACTIONS(305), 7,
+      sym__dedent,
+      sym__string_start,
+      anon_sym_DASH,
+      anon_sym_LPAREN,
+      anon_sym_key_LPAREN,
+      anon_sym_sleep_LPAREN,
+      sym_float,
+  [3789] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(394), 1,
+      anon_sym_COLON,
+    ACTIONS(335), 2,
       sym__simple_identifier,
       aux_sym_word_token1,
-    ACTIONS(321), 8,
+    ACTIONS(337), 8,
       anon_sym_PIPE,
       sym_end_anchor,
       anon_sym_LBRACE,
@@ -5949,14 +6667,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       anon_sym_PLUS,
       anon_sym_LPAREN,
-  [3121] = 8,
+  [3810] = 8,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(371), 1,
+    ACTIONS(397), 1,
       anon_sym_DASH,
-    STATE(145), 1,
+    STATE(165), 1,
       aux_sym_matches_repeat2,
-    STATE(173), 1,
+    STATE(222), 1,
       sym_identifier,
     ACTIONS(11), 2,
       anon_sym_and,
@@ -5964,69 +6682,16 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(43), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    STATE(81), 2,
+    STATE(102), 2,
       sym_match,
       aux_sym_matches_repeat1,
-    STATE(117), 2,
+    STATE(134), 2,
       sym_match_modifier,
       aux_sym_match_repeat1,
-  [3150] = 4,
+  [3839] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(375), 1,
-      anon_sym_LPAREN2,
-    STATE(96), 1,
-      sym_argument_list,
-    ACTIONS(373), 9,
-      anon_sym_DASH,
-      anon_sym_RBRACE,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-      anon_sym_COMMA,
-  [3171] = 7,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(380), 1,
-      anon_sym_DASH,
-    STATE(173), 1,
-      sym_identifier,
-    ACTIONS(377), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    ACTIONS(382), 2,
-      anon_sym_and,
-      anon_sym_not,
-    STATE(81), 2,
-      sym_match,
-      aux_sym_matches_repeat1,
-    STATE(117), 2,
-      sym_match_modifier,
-      aux_sym_match_repeat1,
-  [3197] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(385), 1,
-      anon_sym_EQ,
-    ACTIONS(387), 1,
-      anon_sym_LPAREN2,
-    STATE(131), 1,
-      sym_argument_list,
-    ACTIONS(373), 7,
-      sym__newline,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-  [3219] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(389), 10,
+    ACTIONS(399), 10,
       anon_sym_DASH,
       anon_sym_COLON,
       anon_sym_RBRACE,
@@ -6037,31 +6702,16 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_or,
       anon_sym_COMMA,
-  [3235] = 3,
+  [3855] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(249), 3,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-      sym_integer,
-    ACTIONS(247), 7,
-      sym__dedent,
-      sym__string_start,
-      anon_sym_DASH,
-      anon_sym_LPAREN,
-      anon_sym_key_LPAREN,
-      anon_sym_sleep_LPAREN,
-      sym_float,
-  [3253] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(387), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(391), 1,
+    ACTIONS(401), 1,
       anon_sym_EQ,
-    STATE(131), 1,
+    ACTIONS(403), 1,
+      anon_sym_LPAREN2,
+    STATE(138), 1,
       sym_argument_list,
-    ACTIONS(373), 7,
+    ACTIONS(390), 7,
       sym__newline,
       anon_sym_DASH,
       anon_sym_STAR,
@@ -6069,243 +6719,296 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       anon_sym_PERCENT,
       anon_sym_or,
-  [3275] = 3,
+  [3877] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(273), 3,
+    ACTIONS(405), 10,
+      anon_sym_DASH,
+      anon_sym_COLON,
+      anon_sym_RBRACE,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+      anon_sym_COMMA,
+  [3893] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(409), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(407), 7,
+      anon_sym_DASH,
+      anon_sym_COLON,
+      anon_sym_RBRACE,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_or,
+      anon_sym_COMMA,
+  [3911] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(411), 10,
+      anon_sym_DASH,
+      anon_sym_COLON,
+      anon_sym_RBRACE,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+      anon_sym_COMMA,
+  [3927] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(413), 10,
+      anon_sym_DASH,
+      anon_sym_COLON,
+      anon_sym_RBRACE,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+      anon_sym_COMMA,
+  [3943] = 7,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(418), 1,
+      anon_sym_DASH,
+    STATE(222), 1,
+      sym_identifier,
+    ACTIONS(415), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-      sym_integer,
-    ACTIONS(271), 7,
-      sym__dedent,
-      sym__string_start,
-      anon_sym_DASH,
-      anon_sym_LPAREN,
-      anon_sym_key_LPAREN,
-      anon_sym_sleep_LPAREN,
-      sym_float,
-  [3293] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(233), 3,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-      sym_integer,
-    ACTIONS(231), 7,
-      sym__dedent,
-      sym__string_start,
-      anon_sym_DASH,
-      anon_sym_LPAREN,
-      anon_sym_key_LPAREN,
-      anon_sym_sleep_LPAREN,
-      sym_float,
-  [3311] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(393), 9,
-      anon_sym_DASH,
-      anon_sym_RBRACE,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-      anon_sym_COMMA,
-  [3326] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(395), 9,
-      anon_sym_DASH,
-      anon_sym_RBRACE,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-      anon_sym_COMMA,
-  [3341] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(399), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-    ACTIONS(397), 6,
-      anon_sym_DASH,
-      anon_sym_RBRACE,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_or,
-      anon_sym_COMMA,
-  [3358] = 7,
+    ACTIONS(420), 2,
+      anon_sym_and,
+      anon_sym_not,
+    STATE(102), 2,
+      sym_match,
+      aux_sym_matches_repeat1,
+    STATE(134), 2,
+      sym_match_modifier,
+      aux_sym_match_repeat1,
+  [3969] = 5,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(403), 1,
-      anon_sym_RPAREN,
-    ACTIONS(405), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(423), 1,
+      anon_sym_EQ,
+    STATE(138), 1,
+      sym_argument_list,
+    ACTIONS(390), 7,
+      sym__newline,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
       anon_sym_or,
-    ACTIONS(407), 1,
+  [3991] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(425), 2,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+    ACTIONS(409), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(407), 5,
+      anon_sym_COLON,
+      anon_sym_RBRACE,
+      anon_sym_RPAREN,
+      anon_sym_or,
       anon_sym_COMMA,
-    STATE(152), 1,
+  [4011] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(427), 10,
+      anon_sym_DASH,
+      anon_sym_COLON,
+      anon_sym_RBRACE,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+      anon_sym_COMMA,
+  [4027] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(429), 10,
+      anon_sym_DASH,
+      anon_sym_COLON,
+      anon_sym_RBRACE,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+      anon_sym_COMMA,
+  [4043] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(431), 10,
+      anon_sym_DASH,
+      anon_sym_COLON,
+      anon_sym_RBRACE,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+      anon_sym_COMMA,
+  [4059] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(433), 10,
+      anon_sym_DASH,
+      anon_sym_COLON,
+      anon_sym_RBRACE,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+      anon_sym_COMMA,
+  [4075] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(435), 10,
+      anon_sym_DASH,
+      anon_sym_COLON,
+      anon_sym_RBRACE,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+      anon_sym_COMMA,
+  [4091] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(407), 10,
+      anon_sym_DASH,
+      anon_sym_COLON,
+      anon_sym_RBRACE,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+      anon_sym_COMMA,
+  [4107] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(437), 10,
+      anon_sym_DASH,
+      anon_sym_COLON,
+      anon_sym_RBRACE,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+      anon_sym_COMMA,
+  [4123] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(439), 10,
+      anon_sym_DASH,
+      anon_sym_COLON,
+      anon_sym_RBRACE,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+      anon_sym_COMMA,
+  [4139] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(441), 10,
+      anon_sym_DASH,
+      anon_sym_COLON,
+      anon_sym_RBRACE,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+      anon_sym_COMMA,
+  [4155] = 7,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(443), 1,
+      anon_sym_RPAREN,
+    ACTIONS(445), 1,
+      anon_sym_or,
+    ACTIONS(447), 1,
+      anon_sym_COMMA,
+    STATE(166), 1,
       aux_sym_argument_list_repeat1,
-    ACTIONS(401), 2,
+    ACTIONS(425), 2,
       anon_sym_DASH,
       anon_sym_PLUS,
-    ACTIONS(399), 3,
+    ACTIONS(409), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
-  [3383] = 2,
+  [4180] = 7,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(397), 9,
+    ACTIONS(445), 1,
+      anon_sym_or,
+    ACTIONS(449), 1,
+      anon_sym_RPAREN,
+    ACTIONS(451), 1,
+      anon_sym_COMMA,
+    STATE(161), 1,
+      aux_sym_argument_list_repeat1,
+    ACTIONS(425), 2,
       anon_sym_DASH,
-      anon_sym_RBRACE,
+      anon_sym_PLUS,
+    ACTIONS(409), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4205] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(403), 1,
+      anon_sym_LPAREN2,
+    STATE(138), 1,
+      sym_argument_list,
+    ACTIONS(390), 7,
+      sym__newline,
+      anon_sym_DASH,
       anon_sym_STAR,
       anon_sym_PLUS,
-      anon_sym_RPAREN,
       anon_sym_SLASH,
       anon_sym_PERCENT,
       anon_sym_or,
-      anon_sym_COMMA,
-  [3398] = 4,
+  [4224] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(401), 2,
-      anon_sym_DASH,
-      anon_sym_PLUS,
-    ACTIONS(399), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-    ACTIONS(397), 4,
-      anon_sym_RBRACE,
-      anon_sym_RPAREN,
-      anon_sym_or,
-      anon_sym_COMMA,
-  [3417] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(409), 9,
-      anon_sym_DASH,
-      anon_sym_RBRACE,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-      anon_sym_COMMA,
-  [3432] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(411), 9,
-      anon_sym_DASH,
-      anon_sym_RBRACE,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-      anon_sym_COMMA,
-  [3447] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(413), 9,
-      anon_sym_DASH,
-      anon_sym_RBRACE,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-      anon_sym_COMMA,
-  [3462] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(415), 9,
-      anon_sym_DASH,
-      anon_sym_RBRACE,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-      anon_sym_COMMA,
-  [3477] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(417), 9,
-      anon_sym_DASH,
-      anon_sym_RBRACE,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-      anon_sym_COMMA,
-  [3492] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(419), 9,
-      anon_sym_DASH,
-      anon_sym_RBRACE,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-      anon_sym_COMMA,
-  [3507] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(421), 9,
-      anon_sym_DASH,
-      anon_sym_RBRACE,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-      anon_sym_COMMA,
-  [3522] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(423), 9,
-      anon_sym_DASH,
-      anon_sym_RBRACE,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-      anon_sym_COMMA,
-  [3537] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(425), 9,
-      anon_sym_DASH,
-      anon_sym_RBRACE,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-      anon_sym_COMMA,
-  [3552] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(360), 9,
+    ACTIONS(325), 9,
       sym__newline,
       anon_sym_DASH,
       anon_sym_STAR,
@@ -6315,97 +7018,92 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PERCENT,
       anon_sym_or,
       anon_sym_LPAREN2,
-  [3567] = 7,
-    ACTIONS(3), 1,
+  [4239] = 3,
+    ACTIONS(158), 1,
       sym_comment,
-    ACTIONS(405), 1,
-      anon_sym_or,
-    ACTIONS(427), 1,
-      anon_sym_RPAREN,
-    ACTIONS(429), 1,
-      anon_sym_COMMA,
-    STATE(150), 1,
-      aux_sym_argument_list_repeat1,
-    ACTIONS(401), 2,
-      anon_sym_DASH,
-      anon_sym_PLUS,
-    ACTIONS(399), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [3592] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(387), 1,
-      anon_sym_LPAREN2,
-    STATE(131), 1,
-      sym_argument_list,
-    ACTIONS(373), 7,
-      sym__newline,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-  [3611] = 3,
-    ACTIONS(96), 1,
-      sym_comment,
-    ACTIONS(433), 2,
+    ACTIONS(455), 2,
       sym_string_content,
       sym__string_end,
-    ACTIONS(431), 6,
+    ACTIONS(453), 6,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_LBRACE_LBRACE,
       anon_sym_RBRACE_RBRACE,
       sym_string_escape_sequence,
       sym__not_escapesequence,
-  [3627] = 3,
-    ACTIONS(96), 1,
+  [4255] = 3,
+    ACTIONS(158), 1,
       sym_comment,
-    ACTIONS(112), 2,
+    ACTIONS(174), 2,
       sym_string_content,
       sym__string_end,
-    ACTIONS(100), 6,
+    ACTIONS(162), 6,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_LBRACE_LBRACE,
       anon_sym_RBRACE_RBRACE,
       sym_string_escape_sequence,
       sym__not_escapesequence,
-  [3643] = 5,
+  [4271] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(405), 1,
+    ACTIONS(445), 1,
       anon_sym_or,
-    ACTIONS(401), 2,
+    ACTIONS(425), 2,
       anon_sym_DASH,
       anon_sym_PLUS,
-    ACTIONS(435), 2,
+    ACTIONS(457), 2,
       anon_sym_RPAREN,
       anon_sym_COMMA,
-    ACTIONS(399), 3,
+    ACTIONS(409), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
-  [3663] = 3,
-    ACTIONS(96), 1,
+  [4291] = 3,
+    ACTIONS(158), 1,
       sym_comment,
-    ACTIONS(439), 2,
+    ACTIONS(461), 2,
       sym_string_content,
       sym__string_end,
-    ACTIONS(437), 6,
+    ACTIONS(459), 6,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       anon_sym_LBRACE_LBRACE,
       anon_sym_RBRACE_RBRACE,
       sym_string_escape_sequence,
       sym__not_escapesequence,
-  [3679] = 2,
+  [4307] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(389), 7,
+    ACTIONS(445), 1,
+      anon_sym_or,
+    ACTIONS(463), 1,
+      anon_sym_COLON,
+    ACTIONS(425), 2,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+    ACTIONS(409), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4326] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(469), 1,
+      anon_sym_or,
+    ACTIONS(471), 1,
+      sym__newline,
+    ACTIONS(465), 2,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+    ACTIONS(467), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4345] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(405), 7,
       sym__newline,
       anon_sym_DASH,
       anon_sym_STAR,
@@ -6413,10 +7111,10 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       anon_sym_PERCENT,
       anon_sym_or,
-  [3692] = 2,
+  [4358] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(419), 7,
+    ACTIONS(399), 7,
       sym__newline,
       anon_sym_DASH,
       anon_sym_STAR,
@@ -6424,10 +7122,10 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       anon_sym_PERCENT,
       anon_sym_or,
-  [3705] = 2,
+  [4371] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(425), 7,
+    ACTIONS(437), 7,
       sym__newline,
       anon_sym_DASH,
       anon_sym_STAR,
@@ -6435,35 +7133,212 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       anon_sym_PERCENT,
       anon_sym_or,
-  [3718] = 5,
+  [4384] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(405), 1,
+    ACTIONS(439), 7,
+      sym__newline,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
       anon_sym_or,
-    ACTIONS(441), 1,
+  [4397] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(407), 2,
+      sym__newline,
+      anon_sym_or,
+    ACTIONS(465), 2,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+    ACTIONS(467), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4414] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(445), 1,
+      anon_sym_or,
+    ACTIONS(473), 1,
       anon_sym_RPAREN,
-    ACTIONS(401), 2,
+    ACTIONS(425), 2,
       anon_sym_DASH,
       anon_sym_PLUS,
-    ACTIONS(399), 3,
+    ACTIONS(409), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
-  [3737] = 5,
+  [4433] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(447), 1,
+    ACTIONS(445), 1,
       anon_sym_or,
-    ACTIONS(449), 1,
-      sym__newline,
-    ACTIONS(443), 2,
+    ACTIONS(475), 1,
+      anon_sym_COLON,
+    ACTIONS(425), 2,
       anon_sym_DASH,
       anon_sym_PLUS,
-    ACTIONS(445), 3,
+    ACTIONS(409), 3,
       anon_sym_STAR,
       anon_sym_SLASH,
       anon_sym_PERCENT,
-  [3756] = 2,
+  [4452] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(469), 1,
+      anon_sym_or,
+    ACTIONS(477), 1,
+      sym__newline,
+    ACTIONS(465), 2,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+    ACTIONS(467), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4471] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(445), 1,
+      anon_sym_or,
+    ACTIONS(479), 1,
+      anon_sym_COLON,
+    ACTIONS(425), 2,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+    ACTIONS(409), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4490] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(445), 1,
+      anon_sym_or,
+    ACTIONS(481), 1,
+      anon_sym_RPAREN,
+    ACTIONS(425), 2,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+    ACTIONS(409), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4509] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    STATE(189), 1,
+      sym_identifier,
+    ACTIONS(11), 2,
+      anon_sym_and,
+      anon_sym_not,
+    ACTIONS(43), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+    STATE(149), 2,
+      sym_match_modifier,
+      aux_sym_match_repeat1,
+  [4528] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(435), 7,
+      sym__newline,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+  [4541] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(469), 1,
+      anon_sym_or,
+    ACTIONS(483), 1,
+      sym__newline,
+    ACTIONS(465), 2,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+    ACTIONS(467), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4560] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(427), 7,
+      sym__newline,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+  [4573] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(433), 7,
+      sym__newline,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+  [4586] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(441), 7,
+      sym__newline,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+  [4599] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(469), 1,
+      anon_sym_or,
+    ACTIONS(485), 1,
+      sym__newline,
+    ACTIONS(465), 2,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+    ACTIONS(467), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4618] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(445), 1,
+      anon_sym_or,
+    ACTIONS(487), 1,
+      anon_sym_RBRACE,
+    ACTIONS(425), 2,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+    ACTIONS(409), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4637] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(431), 7,
+      sym__newline,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+  [4650] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(411), 7,
@@ -6474,193 +7349,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       anon_sym_PERCENT,
       anon_sym_or,
-  [3769] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(393), 7,
-      sym__newline,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-  [3782] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    STATE(198), 1,
-      sym_identifier,
-    ACTIONS(11), 2,
-      anon_sym_and,
-      anon_sym_not,
-    ACTIONS(43), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-    STATE(133), 2,
-      sym_match_modifier,
-      aux_sym_match_repeat1,
-  [3801] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(405), 1,
-      anon_sym_or,
-    ACTIONS(451), 1,
-      anon_sym_RBRACE,
-    ACTIONS(401), 2,
-      anon_sym_DASH,
-      anon_sym_PLUS,
-    ACTIONS(399), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [3820] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(447), 1,
-      anon_sym_or,
-    ACTIONS(453), 1,
-      sym__newline,
-    ACTIONS(443), 2,
-      anon_sym_DASH,
-      anon_sym_PLUS,
-    ACTIONS(445), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [3839] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(423), 7,
-      sym__newline,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-  [3852] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(447), 1,
-      anon_sym_or,
-    ACTIONS(455), 1,
-      sym__newline,
-    ACTIONS(443), 2,
-      anon_sym_DASH,
-      anon_sym_PLUS,
-    ACTIONS(445), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [3871] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(395), 7,
-      sym__newline,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-  [3884] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(447), 1,
-      anon_sym_or,
-    ACTIONS(457), 1,
-      sym__newline,
-    ACTIONS(443), 2,
-      anon_sym_DASH,
-      anon_sym_PLUS,
-    ACTIONS(445), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [3903] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(409), 7,
-      sym__newline,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-  [3916] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(421), 7,
-      sym__newline,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-  [3929] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(405), 1,
-      anon_sym_or,
-    ACTIONS(459), 1,
-      anon_sym_RPAREN,
-    ACTIONS(401), 2,
-      anon_sym_DASH,
-      anon_sym_PLUS,
-    ACTIONS(399), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [3948] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(417), 7,
-      sym__newline,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-  [3961] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(397), 2,
-      sym__newline,
-      anon_sym_or,
-    ACTIONS(443), 2,
-      anon_sym_DASH,
-      anon_sym_PLUS,
-    ACTIONS(445), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-  [3978] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(415), 7,
-      sym__newline,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      anon_sym_or,
-  [3991] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(445), 3,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-    ACTIONS(397), 4,
-      sym__newline,
-      anon_sym_DASH,
-      anon_sym_PLUS,
-      anon_sym_or,
-  [4006] = 2,
+  [4663] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(413), 7,
@@ -6671,10 +7360,24 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       anon_sym_PERCENT,
       anon_sym_or,
-  [4019] = 2,
+  [4676] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(397), 7,
+    ACTIONS(445), 1,
+      anon_sym_or,
+    ACTIONS(489), 1,
+      anon_sym_COLON,
+    ACTIONS(425), 2,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+    ACTIONS(409), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+  [4695] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(429), 7,
       sym__newline,
       anon_sym_DASH,
       anon_sym_STAR,
@@ -6682,486 +7385,535 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       anon_sym_PERCENT,
       anon_sym_or,
-  [4032] = 4,
+  [4708] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(461), 2,
+    ACTIONS(467), 3,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(407), 4,
+      sym__newline,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+      anon_sym_or,
+  [4723] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(407), 7,
+      sym__newline,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      anon_sym_or,
+  [4736] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(491), 2,
       sym__simple_identifier,
       aux_sym_identifier_token1,
-    ACTIONS(463), 2,
+    ACTIONS(493), 2,
       anon_sym_and,
       anon_sym_not,
-    STATE(133), 2,
+    STATE(149), 2,
       sym_match_modifier,
       aux_sym_match_repeat1,
-  [4048] = 3,
+  [4752] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(468), 1,
+    ACTIONS(498), 1,
       sym_end_anchor,
-    ACTIONS(466), 4,
+    ACTIONS(496), 4,
       anon_sym_COLON,
       anon_sym_PIPE,
       anon_sym_RBRACK,
       anon_sym_RPAREN,
-  [4061] = 3,
+  [4765] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(472), 1,
+    ACTIONS(502), 1,
+      anon_sym_PIPE,
+    STATE(151), 1,
+      aux_sym_choice_repeat1,
+    ACTIONS(500), 3,
+      anon_sym_COLON,
+      anon_sym_RBRACK,
+      anon_sym_RPAREN,
+  [4780] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(507), 1,
+      anon_sym_PIPE,
+    STATE(156), 1,
+      aux_sym_choice_repeat1,
+    ACTIONS(505), 3,
+      anon_sym_COLON,
+      anon_sym_RBRACK,
+      anon_sym_RPAREN,
+  [4795] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(511), 1,
       anon_sym_DASH,
-    ACTIONS(470), 4,
+    ACTIONS(509), 4,
       sym__simple_identifier,
       anon_sym_and,
       anon_sym_not,
       aux_sym_identifier_token1,
-  [4074] = 4,
+  [4808] = 3,
     ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(476), 1,
-      anon_sym_PIPE,
-    STATE(138), 1,
-      aux_sym_choice_repeat1,
-    ACTIONS(474), 3,
-      anon_sym_COLON,
-      anon_sym_RBRACK,
-      anon_sym_RPAREN,
-  [4089] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(480), 1,
-      anon_sym_DASH,
-    ACTIONS(478), 4,
-      sym__simple_identifier,
-      anon_sym_and,
-      anon_sym_not,
-      aux_sym_identifier_token1,
-  [4102] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(484), 1,
-      anon_sym_PIPE,
-    STATE(138), 1,
-      aux_sym_choice_repeat1,
-    ACTIONS(482), 3,
-      anon_sym_COLON,
-      anon_sym_RBRACK,
-      anon_sym_RPAREN,
-  [4117] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(489), 1,
-      sym_end_anchor,
-    ACTIONS(487), 4,
-      anon_sym_COLON,
-      anon_sym_PIPE,
-      anon_sym_RBRACK,
-      anon_sym_RPAREN,
-  [4130] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(476), 1,
-      anon_sym_PIPE,
-    STATE(136), 1,
-      aux_sym_choice_repeat1,
-    ACTIONS(491), 3,
-      anon_sym_COLON,
-      anon_sym_RBRACK,
-      anon_sym_RPAREN,
-  [4145] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(493), 4,
-      anon_sym_COLON,
-      anon_sym_PIPE,
-      anon_sym_RBRACK,
-      anon_sym_RPAREN,
-  [4155] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(487), 4,
-      anon_sym_COLON,
-      anon_sym_PIPE,
-      anon_sym_RBRACK,
-      anon_sym_RPAREN,
-  [4165] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(495), 4,
-      sym__simple_identifier,
-      anon_sym_and,
-      anon_sym_not,
-      aux_sym_identifier_token1,
-  [4175] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(482), 4,
-      anon_sym_COLON,
-      anon_sym_PIPE,
-      anon_sym_RBRACK,
-      anon_sym_RPAREN,
-  [4185] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(497), 1,
-      anon_sym_DASH,
-    ACTIONS(499), 1,
-      sym__newline,
-    STATE(151), 1,
-      aux_sym_matches_repeat2,
-  [4198] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(497), 1,
-      anon_sym_DASH,
-    ACTIONS(501), 1,
-      sym__newline,
-    STATE(151), 1,
-      aux_sym_matches_repeat2,
-  [4211] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    STATE(169), 1,
-      sym_identifier,
-    ACTIONS(43), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-  [4222] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    STATE(168), 1,
-      sym_identifier,
-    ACTIONS(43), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-  [4233] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    STATE(202), 1,
-      sym_identifier,
-    ACTIONS(114), 2,
-      sym__simple_identifier,
-      aux_sym_identifier_token1,
-  [4244] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(209), 1,
-      anon_sym_RPAREN,
-    ACTIONS(503), 1,
-      anon_sym_COMMA,
-    STATE(153), 1,
-      aux_sym_argument_list_repeat1,
-  [4257] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(505), 1,
-      anon_sym_DASH,
-    ACTIONS(508), 1,
-      sym__newline,
-    STATE(151), 1,
-      aux_sym_matches_repeat2,
-  [4270] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(186), 1,
-      anon_sym_RPAREN,
-    ACTIONS(510), 1,
-      anon_sym_COMMA,
-    STATE(153), 1,
-      aux_sym_argument_list_repeat1,
-  [4283] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(435), 1,
-      anon_sym_RPAREN,
-    ACTIONS(512), 1,
-      anon_sym_COMMA,
-    STATE(153), 1,
-      aux_sym_argument_list_repeat1,
-  [4296] = 3,
-    ACTIONS(96), 1,
       sym_comment,
     ACTIONS(515), 1,
-      aux_sym__implicit_string_argument_token1,
-    STATE(194), 1,
-      sym__implicit_string_argument,
-  [4306] = 3,
-    ACTIONS(96), 1,
-      sym_comment,
-    ACTIONS(517), 1,
-      aux_sym__implicit_string_argument_token1,
-    STATE(185), 1,
-      sym__implicit_string_argument,
-  [4316] = 3,
-    ACTIONS(96), 1,
+      sym_end_anchor,
+    ACTIONS(513), 4,
+      anon_sym_COLON,
+      anon_sym_PIPE,
+      anon_sym_RBRACK,
+      anon_sym_RPAREN,
+  [4821] = 3,
+    ACTIONS(3), 1,
       sym_comment,
     ACTIONS(519), 1,
-      aux_sym__implicit_string_argument_token1,
-    STATE(189), 1,
-      sym__implicit_string_argument,
-  [4326] = 3,
-    ACTIONS(96), 1,
+      anon_sym_DASH,
+    ACTIONS(517), 4,
+      sym__simple_identifier,
+      anon_sym_and,
+      anon_sym_not,
+      aux_sym_identifier_token1,
+  [4834] = 4,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(521), 1,
-      aux_sym__implicit_string_argument_token1,
-    STATE(195), 1,
-      sym__implicit_string_argument,
-  [4336] = 3,
-    ACTIONS(96), 1,
+    ACTIONS(507), 1,
+      anon_sym_PIPE,
+    STATE(151), 1,
+      aux_sym_choice_repeat1,
+    ACTIONS(521), 3,
+      anon_sym_COLON,
+      anon_sym_RBRACK,
+      anon_sym_RPAREN,
+  [4849] = 2,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(523), 1,
-      aux_sym__implicit_string_argument_token1,
-    STATE(199), 1,
-      sym__implicit_string_argument,
-  [4346] = 3,
-    ACTIONS(96), 1,
+    ACTIONS(523), 4,
+      anon_sym_COLON,
+      anon_sym_PIPE,
+      anon_sym_RBRACK,
+      anon_sym_RPAREN,
+  [4859] = 2,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(525), 1,
-      aux_sym__implicit_string_argument_token1,
-    STATE(200), 1,
-      sym__implicit_string_argument,
-  [4356] = 3,
-    ACTIONS(96), 1,
+    ACTIONS(525), 4,
+      sym__simple_identifier,
+      anon_sym_and,
+      anon_sym_not,
+      aux_sym_identifier_token1,
+  [4869] = 2,
+    ACTIONS(3), 1,
       sym_comment,
+    ACTIONS(500), 4,
+      anon_sym_COLON,
+      anon_sym_PIPE,
+      anon_sym_RBRACK,
+      anon_sym_RPAREN,
+  [4879] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(513), 4,
+      anon_sym_COLON,
+      anon_sym_PIPE,
+      anon_sym_RBRACK,
+      anon_sym_RPAREN,
+  [4889] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(221), 1,
+      anon_sym_RPAREN,
     ACTIONS(527), 1,
-      aux_sym__implicit_string_argument_token1,
-    STATE(196), 1,
-      sym__implicit_string_argument,
-  [4366] = 3,
-    ACTIONS(96), 1,
+      anon_sym_COMMA,
+    STATE(171), 1,
+      aux_sym_argument_list_repeat1,
+  [4902] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    STATE(216), 1,
+      sym_identifier,
+    ACTIONS(96), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+  [4913] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    STATE(225), 1,
+      sym_identifier,
+    ACTIONS(43), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+  [4924] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    STATE(211), 1,
+      sym_identifier,
+    ACTIONS(43), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+  [4935] = 4,
+    ACTIONS(3), 1,
       sym_comment,
     ACTIONS(529), 1,
-      aux_sym__implicit_string_argument_token1,
-    STATE(201), 1,
-      sym__implicit_string_argument,
-  [4376] = 3,
-    ACTIONS(96), 1,
-      sym_comment,
+      anon_sym_DASH,
     ACTIONS(531), 1,
-      aux_sym__implicit_string_argument_token1,
-    STATE(203), 1,
-      sym__implicit_string_argument,
-  [4386] = 3,
-    ACTIONS(96), 1,
+      sym__newline,
+    STATE(167), 1,
+      aux_sym_matches_repeat2,
+  [4948] = 4,
+    ACTIONS(3), 1,
       sym_comment,
+    ACTIONS(223), 1,
+      anon_sym_RPAREN,
     ACTIONS(533), 1,
-      aux_sym__implicit_string_argument_token1,
-    STATE(205), 1,
-      sym__implicit_string_argument,
-  [4396] = 2,
+      anon_sym_COMMA,
+    STATE(171), 1,
+      aux_sym_argument_list_repeat1,
+  [4961] = 4,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(535), 1,
-      anon_sym_COLON,
-  [4403] = 2,
+      anon_sym_DASH,
+    ACTIONS(538), 1,
+      sym__newline,
+    STATE(167), 1,
+      aux_sym_matches_repeat2,
+  [4974] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(45), 1,
-      ts_builtin_sym_end,
-  [4410] = 2,
+    STATE(219), 1,
+      sym_identifier,
+    ACTIONS(43), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+  [4985] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(537), 1,
+    STATE(194), 1,
+      sym_identifier,
+    ACTIONS(43), 2,
+      sym__simple_identifier,
+      aux_sym_identifier_token1,
+  [4996] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(529), 1,
+      anon_sym_DASH,
+    ACTIONS(540), 1,
+      sym__newline,
+    STATE(167), 1,
+      aux_sym_matches_repeat2,
+  [5009] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(457), 1,
       anon_sym_RPAREN,
-  [4417] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(539), 1,
-      anon_sym_RBRACK,
-  [4424] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(541), 1,
-      anon_sym_GT,
-  [4431] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(543), 1,
-      anon_sym_RBRACE,
-  [4438] = 2,
-    ACTIONS(3), 1,
+    ACTIONS(542), 1,
+      anon_sym_COMMA,
+    STATE(171), 1,
+      aux_sym_argument_list_repeat1,
+  [5022] = 3,
+    ACTIONS(158), 1,
       sym_comment,
     ACTIONS(545), 1,
-      anon_sym_COLON,
-  [4445] = 2,
-    ACTIONS(3), 1,
+      aux_sym__implicit_string_argument_token1,
+    STATE(202), 1,
+      sym__implicit_string_argument,
+  [5032] = 3,
+    ACTIONS(158), 1,
       sym_comment,
     ACTIONS(547), 1,
-      anon_sym_COLON,
-  [4452] = 2,
-    ACTIONS(3), 1,
+      aux_sym__implicit_string_argument_token1,
+    STATE(198), 1,
+      sym__implicit_string_argument,
+  [5042] = 3,
+    ACTIONS(158), 1,
       sym_comment,
     ACTIONS(549), 1,
-      anon_sym_COLON,
-  [4459] = 2,
-    ACTIONS(3), 1,
+      aux_sym__implicit_string_argument_token1,
+    STATE(206), 1,
+      sym__implicit_string_argument,
+  [5052] = 3,
+    ACTIONS(158), 1,
       sym_comment,
     ACTIONS(551), 1,
-      anon_sym_COLON,
-  [4466] = 2,
-    ACTIONS(3), 1,
+      aux_sym__implicit_string_argument_token1,
+    STATE(201), 1,
+      sym__implicit_string_argument,
+  [5062] = 3,
+    ACTIONS(158), 1,
       sym_comment,
     ACTIONS(553), 1,
-      anon_sym_COLON,
-  [4473] = 2,
-    ACTIONS(3), 1,
+      aux_sym__implicit_string_argument_token1,
+    STATE(196), 1,
+      sym__implicit_string_argument,
+  [5072] = 3,
+    ACTIONS(158), 1,
       sym_comment,
     ACTIONS(555), 1,
-      anon_sym_COLON,
-  [4480] = 2,
-    ACTIONS(96), 1,
+      aux_sym__implicit_string_argument_token1,
+    STATE(204), 1,
+      sym__implicit_string_argument,
+  [5082] = 3,
+    ACTIONS(158), 1,
       sym_comment,
     ACTIONS(557), 1,
-      sym_implicit_string,
-  [4487] = 2,
-    ACTIONS(3), 1,
+      aux_sym__implicit_string_argument_token1,
+    STATE(203), 1,
+      sym__implicit_string_argument,
+  [5092] = 3,
+    ACTIONS(158), 1,
       sym_comment,
     ACTIONS(559), 1,
-      anon_sym_COLON,
-  [4494] = 2,
-    ACTIONS(3), 1,
+      aux_sym__implicit_string_argument_token1,
+    STATE(197), 1,
+      sym__implicit_string_argument,
+  [5102] = 3,
+    ACTIONS(158), 1,
       sym_comment,
     ACTIONS(561), 1,
-      anon_sym_COLON,
-  [4501] = 2,
-    ACTIONS(3), 1,
+      aux_sym__implicit_string_argument_token1,
+    STATE(200), 1,
+      sym__implicit_string_argument,
+  [5112] = 3,
+    ACTIONS(158), 1,
       sym_comment,
     ACTIONS(563), 1,
-      anon_sym_COLON,
-  [4508] = 2,
+      aux_sym__implicit_string_argument_token1,
+    STATE(182), 1,
+      sym__implicit_string_argument,
+  [5122] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(565), 1,
-      anon_sym_COLON,
-  [4515] = 2,
+      anon_sym_RPAREN,
+  [5129] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(567), 1,
-      anon_sym_COLON,
-  [4522] = 2,
-    ACTIONS(96), 1,
+      anon_sym_RPAREN,
+  [5136] = 2,
+    ACTIONS(3), 1,
       sym_comment,
     ACTIONS(569), 1,
-      sym_implicit_string,
-  [4529] = 2,
+      anon_sym_COLON,
+  [5143] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(571), 1,
       anon_sym_COLON,
-  [4536] = 2,
+  [5150] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(573), 1,
       anon_sym_COLON,
-  [4543] = 2,
+  [5157] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(575), 1,
-      anon_sym_RPAREN,
-  [4550] = 2,
+      anon_sym_COLON,
+  [5164] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(577), 1,
-      ts_builtin_sym_end,
-  [4557] = 2,
+      anon_sym_COLON,
+  [5171] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(579), 1,
-      sym__newline,
-  [4564] = 2,
+      anon_sym_COLON,
+  [5178] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(581), 1,
       anon_sym_COLON,
-  [4571] = 2,
+  [5185] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(583), 1,
-      anon_sym_RPAREN,
-  [4578] = 2,
-    ACTIONS(3), 1,
+      ts_builtin_sym_end,
+  [5192] = 2,
+    ACTIONS(158), 1,
       sym_comment,
     ACTIONS(585), 1,
-      anon_sym_COLON,
-  [4585] = 2,
+      sym_implicit_string,
+  [5199] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(45), 1,
+      ts_builtin_sym_end,
+  [5206] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(587), 1,
-      anon_sym_COLON,
-  [4592] = 2,
+      anon_sym_in,
+  [5213] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(589), 1,
-      anon_sym_COLON,
-  [4599] = 2,
+      ts_builtin_sym_end,
+  [5220] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(591), 1,
-      sym__newline,
-  [4606] = 2,
+      anon_sym_RPAREN,
+  [5227] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(593), 1,
       anon_sym_RPAREN,
-  [4613] = 2,
+  [5234] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(595), 1,
       anon_sym_RPAREN,
-  [4620] = 2,
+  [5241] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(597), 1,
-      anon_sym_RPAREN,
-  [4627] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(427), 1,
-      anon_sym_RPAREN,
-  [4634] = 2,
+      anon_sym_COLON,
+  [5248] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(599), 1,
-      anon_sym_COLON,
-  [4641] = 2,
+      anon_sym_RPAREN,
+  [5255] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(601), 1,
       anon_sym_RPAREN,
-  [4648] = 2,
+  [5262] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(603), 1,
       anon_sym_RPAREN,
-  [4655] = 2,
+  [5269] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(605), 1,
       anon_sym_RPAREN,
-  [4662] = 2,
+  [5276] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(607), 1,
-      sym__newline,
-  [4669] = 2,
+      anon_sym_RPAREN,
+  [5283] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(609), 1,
-      anon_sym_RPAREN,
-  [4676] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(403), 1,
-      anon_sym_RPAREN,
-  [4683] = 2,
+      anon_sym_COLON,
+  [5290] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(611), 1,
       anon_sym_RPAREN,
-  [4690] = 2,
-    ACTIONS(3), 1,
+  [5297] = 2,
+    ACTIONS(158), 1,
       sym_comment,
     ACTIONS(613), 1,
-      ts_builtin_sym_end,
+      sym_implicit_string,
+  [5304] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(615), 1,
+      sym__newline,
+  [5311] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(617), 1,
+      anon_sym_RBRACK,
+  [5318] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(449), 1,
+      anon_sym_RPAREN,
+  [5325] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(619), 1,
+      anon_sym_GT,
+  [5332] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(621), 1,
+      anon_sym_COLON,
+  [5339] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(623), 1,
+      anon_sym_COLON,
+  [5346] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(625), 1,
+      anon_sym_COLON,
+  [5353] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(627), 1,
+      anon_sym_COLON,
+  [5360] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(629), 1,
+      sym__newline,
+  [5367] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(631), 1,
+      anon_sym_COLON,
+  [5374] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(633), 1,
+      sym__newline,
+  [5381] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(635), 1,
+      anon_sym_RBRACE,
+  [5388] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(637), 1,
+      anon_sym_COLON,
+  [5395] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(443), 1,
+      anon_sym_RPAREN,
+  [5402] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(639), 1,
+      anon_sym_COLON,
+  [5409] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(641), 1,
+      anon_sym_COLON,
+  [5416] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(643), 1,
+      anon_sym_COLON,
+  [5423] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(645), 1,
+      anon_sym_in,
+  [5430] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(647), 1,
+      anon_sym_COLON,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
@@ -7169,207 +7921,227 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(3)] = 117,
   [SMALL_STATE(4)] = 231,
   [SMALL_STATE(5)] = 345,
-  [SMALL_STATE(6)] = 400,
-  [SMALL_STATE(7)] = 459,
-  [SMALL_STATE(8)] = 517,
-  [SMALL_STATE(9)] = 575,
-  [SMALL_STATE(10)] = 631,
-  [SMALL_STATE(11)] = 689,
-  [SMALL_STATE(12)] = 745,
-  [SMALL_STATE(13)] = 803,
-  [SMALL_STATE(14)] = 861,
-  [SMALL_STATE(15)] = 919,
-  [SMALL_STATE(16)] = 977,
-  [SMALL_STATE(17)] = 1035,
-  [SMALL_STATE(18)] = 1093,
-  [SMALL_STATE(19)] = 1139,
-  [SMALL_STATE(20)] = 1190,
-  [SMALL_STATE(21)] = 1241,
-  [SMALL_STATE(22)] = 1285,
-  [SMALL_STATE(23)] = 1333,
-  [SMALL_STATE(24)] = 1381,
-  [SMALL_STATE(25)] = 1429,
-  [SMALL_STATE(26)] = 1469,
-  [SMALL_STATE(27)] = 1509,
-  [SMALL_STATE(28)] = 1553,
-  [SMALL_STATE(29)] = 1601,
-  [SMALL_STATE(30)] = 1646,
-  [SMALL_STATE(31)] = 1691,
-  [SMALL_STATE(32)] = 1736,
-  [SMALL_STATE(33)] = 1781,
-  [SMALL_STATE(34)] = 1826,
-  [SMALL_STATE(35)] = 1871,
-  [SMALL_STATE(36)] = 1916,
-  [SMALL_STATE(37)] = 1961,
-  [SMALL_STATE(38)] = 2006,
-  [SMALL_STATE(39)] = 2051,
-  [SMALL_STATE(40)] = 2096,
-  [SMALL_STATE(41)] = 2141,
-  [SMALL_STATE(42)] = 2186,
-  [SMALL_STATE(43)] = 2226,
-  [SMALL_STATE(44)] = 2251,
-  [SMALL_STATE(45)] = 2276,
-  [SMALL_STATE(46)] = 2301,
-  [SMALL_STATE(47)] = 2326,
-  [SMALL_STATE(48)] = 2351,
-  [SMALL_STATE(49)] = 2376,
-  [SMALL_STATE(50)] = 2401,
-  [SMALL_STATE(51)] = 2426,
-  [SMALL_STATE(52)] = 2451,
-  [SMALL_STATE(53)] = 2476,
-  [SMALL_STATE(54)] = 2501,
-  [SMALL_STATE(55)] = 2526,
-  [SMALL_STATE(56)] = 2551,
-  [SMALL_STATE(57)] = 2576,
-  [SMALL_STATE(58)] = 2601,
-  [SMALL_STATE(59)] = 2626,
-  [SMALL_STATE(60)] = 2651,
-  [SMALL_STATE(61)] = 2676,
-  [SMALL_STATE(62)] = 2701,
-  [SMALL_STATE(63)] = 2726,
-  [SMALL_STATE(64)] = 2760,
-  [SMALL_STATE(65)] = 2785,
-  [SMALL_STATE(66)] = 2806,
-  [SMALL_STATE(67)] = 2827,
-  [SMALL_STATE(68)] = 2848,
-  [SMALL_STATE(69)] = 2869,
-  [SMALL_STATE(70)] = 2890,
-  [SMALL_STATE(71)] = 2911,
-  [SMALL_STATE(72)] = 2932,
-  [SMALL_STATE(73)] = 2962,
-  [SMALL_STATE(74)] = 2992,
-  [SMALL_STATE(75)] = 3022,
-  [SMALL_STATE(76)] = 3052,
-  [SMALL_STATE(77)] = 3070,
-  [SMALL_STATE(78)] = 3100,
-  [SMALL_STATE(79)] = 3121,
-  [SMALL_STATE(80)] = 3150,
-  [SMALL_STATE(81)] = 3171,
-  [SMALL_STATE(82)] = 3197,
-  [SMALL_STATE(83)] = 3219,
-  [SMALL_STATE(84)] = 3235,
-  [SMALL_STATE(85)] = 3253,
-  [SMALL_STATE(86)] = 3275,
-  [SMALL_STATE(87)] = 3293,
-  [SMALL_STATE(88)] = 3311,
-  [SMALL_STATE(89)] = 3326,
-  [SMALL_STATE(90)] = 3341,
-  [SMALL_STATE(91)] = 3358,
-  [SMALL_STATE(92)] = 3383,
-  [SMALL_STATE(93)] = 3398,
-  [SMALL_STATE(94)] = 3417,
-  [SMALL_STATE(95)] = 3432,
-  [SMALL_STATE(96)] = 3447,
-  [SMALL_STATE(97)] = 3462,
-  [SMALL_STATE(98)] = 3477,
-  [SMALL_STATE(99)] = 3492,
-  [SMALL_STATE(100)] = 3507,
-  [SMALL_STATE(101)] = 3522,
-  [SMALL_STATE(102)] = 3537,
-  [SMALL_STATE(103)] = 3552,
-  [SMALL_STATE(104)] = 3567,
-  [SMALL_STATE(105)] = 3592,
-  [SMALL_STATE(106)] = 3611,
-  [SMALL_STATE(107)] = 3627,
-  [SMALL_STATE(108)] = 3643,
-  [SMALL_STATE(109)] = 3663,
-  [SMALL_STATE(110)] = 3679,
-  [SMALL_STATE(111)] = 3692,
-  [SMALL_STATE(112)] = 3705,
-  [SMALL_STATE(113)] = 3718,
-  [SMALL_STATE(114)] = 3737,
-  [SMALL_STATE(115)] = 3756,
-  [SMALL_STATE(116)] = 3769,
-  [SMALL_STATE(117)] = 3782,
-  [SMALL_STATE(118)] = 3801,
-  [SMALL_STATE(119)] = 3820,
-  [SMALL_STATE(120)] = 3839,
-  [SMALL_STATE(121)] = 3852,
-  [SMALL_STATE(122)] = 3871,
-  [SMALL_STATE(123)] = 3884,
-  [SMALL_STATE(124)] = 3903,
-  [SMALL_STATE(125)] = 3916,
-  [SMALL_STATE(126)] = 3929,
-  [SMALL_STATE(127)] = 3948,
-  [SMALL_STATE(128)] = 3961,
-  [SMALL_STATE(129)] = 3978,
-  [SMALL_STATE(130)] = 3991,
-  [SMALL_STATE(131)] = 4006,
-  [SMALL_STATE(132)] = 4019,
-  [SMALL_STATE(133)] = 4032,
-  [SMALL_STATE(134)] = 4048,
-  [SMALL_STATE(135)] = 4061,
-  [SMALL_STATE(136)] = 4074,
-  [SMALL_STATE(137)] = 4089,
-  [SMALL_STATE(138)] = 4102,
-  [SMALL_STATE(139)] = 4117,
-  [SMALL_STATE(140)] = 4130,
-  [SMALL_STATE(141)] = 4145,
-  [SMALL_STATE(142)] = 4155,
-  [SMALL_STATE(143)] = 4165,
-  [SMALL_STATE(144)] = 4175,
-  [SMALL_STATE(145)] = 4185,
-  [SMALL_STATE(146)] = 4198,
-  [SMALL_STATE(147)] = 4211,
-  [SMALL_STATE(148)] = 4222,
-  [SMALL_STATE(149)] = 4233,
-  [SMALL_STATE(150)] = 4244,
-  [SMALL_STATE(151)] = 4257,
-  [SMALL_STATE(152)] = 4270,
-  [SMALL_STATE(153)] = 4283,
-  [SMALL_STATE(154)] = 4296,
-  [SMALL_STATE(155)] = 4306,
-  [SMALL_STATE(156)] = 4316,
-  [SMALL_STATE(157)] = 4326,
-  [SMALL_STATE(158)] = 4336,
-  [SMALL_STATE(159)] = 4346,
-  [SMALL_STATE(160)] = 4356,
-  [SMALL_STATE(161)] = 4366,
-  [SMALL_STATE(162)] = 4376,
-  [SMALL_STATE(163)] = 4386,
-  [SMALL_STATE(164)] = 4396,
-  [SMALL_STATE(165)] = 4403,
-  [SMALL_STATE(166)] = 4410,
-  [SMALL_STATE(167)] = 4417,
-  [SMALL_STATE(168)] = 4424,
-  [SMALL_STATE(169)] = 4431,
-  [SMALL_STATE(170)] = 4438,
-  [SMALL_STATE(171)] = 4445,
-  [SMALL_STATE(172)] = 4452,
-  [SMALL_STATE(173)] = 4459,
-  [SMALL_STATE(174)] = 4466,
-  [SMALL_STATE(175)] = 4473,
-  [SMALL_STATE(176)] = 4480,
-  [SMALL_STATE(177)] = 4487,
-  [SMALL_STATE(178)] = 4494,
-  [SMALL_STATE(179)] = 4501,
-  [SMALL_STATE(180)] = 4508,
-  [SMALL_STATE(181)] = 4515,
-  [SMALL_STATE(182)] = 4522,
-  [SMALL_STATE(183)] = 4529,
-  [SMALL_STATE(184)] = 4536,
-  [SMALL_STATE(185)] = 4543,
-  [SMALL_STATE(186)] = 4550,
-  [SMALL_STATE(187)] = 4557,
-  [SMALL_STATE(188)] = 4564,
-  [SMALL_STATE(189)] = 4571,
-  [SMALL_STATE(190)] = 4578,
-  [SMALL_STATE(191)] = 4585,
-  [SMALL_STATE(192)] = 4592,
-  [SMALL_STATE(193)] = 4599,
-  [SMALL_STATE(194)] = 4606,
-  [SMALL_STATE(195)] = 4613,
-  [SMALL_STATE(196)] = 4620,
-  [SMALL_STATE(197)] = 4627,
-  [SMALL_STATE(198)] = 4634,
-  [SMALL_STATE(199)] = 4641,
-  [SMALL_STATE(200)] = 4648,
-  [SMALL_STATE(201)] = 4655,
-  [SMALL_STATE(202)] = 4662,
-  [SMALL_STATE(203)] = 4669,
-  [SMALL_STATE(204)] = 4676,
-  [SMALL_STATE(205)] = 4683,
-  [SMALL_STATE(206)] = 4690,
+  [SMALL_STATE(6)] = 412,
+  [SMALL_STATE(7)] = 478,
+  [SMALL_STATE(8)] = 544,
+  [SMALL_STATE(9)] = 610,
+  [SMALL_STATE(10)] = 676,
+  [SMALL_STATE(11)] = 742,
+  [SMALL_STATE(12)] = 808,
+  [SMALL_STATE(13)] = 874,
+  [SMALL_STATE(14)] = 940,
+  [SMALL_STATE(15)] = 1004,
+  [SMALL_STATE(16)] = 1068,
+  [SMALL_STATE(17)] = 1134,
+  [SMALL_STATE(18)] = 1189,
+  [SMALL_STATE(19)] = 1249,
+  [SMALL_STATE(20)] = 1309,
+  [SMALL_STATE(21)] = 1369,
+  [SMALL_STATE(22)] = 1429,
+  [SMALL_STATE(23)] = 1475,
+  [SMALL_STATE(24)] = 1526,
+  [SMALL_STATE(25)] = 1577,
+  [SMALL_STATE(26)] = 1621,
+  [SMALL_STATE(27)] = 1661,
+  [SMALL_STATE(28)] = 1709,
+  [SMALL_STATE(29)] = 1757,
+  [SMALL_STATE(30)] = 1797,
+  [SMALL_STATE(31)] = 1841,
+  [SMALL_STATE(32)] = 1889,
+  [SMALL_STATE(33)] = 1937,
+  [SMALL_STATE(34)] = 1982,
+  [SMALL_STATE(35)] = 2027,
+  [SMALL_STATE(36)] = 2072,
+  [SMALL_STATE(37)] = 2117,
+  [SMALL_STATE(38)] = 2162,
+  [SMALL_STATE(39)] = 2207,
+  [SMALL_STATE(40)] = 2252,
+  [SMALL_STATE(41)] = 2297,
+  [SMALL_STATE(42)] = 2342,
+  [SMALL_STATE(43)] = 2387,
+  [SMALL_STATE(44)] = 2432,
+  [SMALL_STATE(45)] = 2477,
+  [SMALL_STATE(46)] = 2522,
+  [SMALL_STATE(47)] = 2567,
+  [SMALL_STATE(48)] = 2612,
+  [SMALL_STATE(49)] = 2657,
+  [SMALL_STATE(50)] = 2702,
+  [SMALL_STATE(51)] = 2742,
+  [SMALL_STATE(52)] = 2767,
+  [SMALL_STATE(53)] = 2792,
+  [SMALL_STATE(54)] = 2817,
+  [SMALL_STATE(55)] = 2842,
+  [SMALL_STATE(56)] = 2867,
+  [SMALL_STATE(57)] = 2892,
+  [SMALL_STATE(58)] = 2917,
+  [SMALL_STATE(59)] = 2942,
+  [SMALL_STATE(60)] = 2967,
+  [SMALL_STATE(61)] = 2992,
+  [SMALL_STATE(62)] = 3017,
+  [SMALL_STATE(63)] = 3042,
+  [SMALL_STATE(64)] = 3067,
+  [SMALL_STATE(65)] = 3092,
+  [SMALL_STATE(66)] = 3117,
+  [SMALL_STATE(67)] = 3142,
+  [SMALL_STATE(68)] = 3167,
+  [SMALL_STATE(69)] = 3192,
+  [SMALL_STATE(70)] = 3217,
+  [SMALL_STATE(71)] = 3242,
+  [SMALL_STATE(72)] = 3267,
+  [SMALL_STATE(73)] = 3292,
+  [SMALL_STATE(74)] = 3326,
+  [SMALL_STATE(75)] = 3347,
+  [SMALL_STATE(76)] = 3368,
+  [SMALL_STATE(77)] = 3389,
+  [SMALL_STATE(78)] = 3408,
+  [SMALL_STATE(79)] = 3433,
+  [SMALL_STATE(80)] = 3454,
+  [SMALL_STATE(81)] = 3475,
+  [SMALL_STATE(82)] = 3496,
+  [SMALL_STATE(83)] = 3517,
+  [SMALL_STATE(84)] = 3537,
+  [SMALL_STATE(85)] = 3567,
+  [SMALL_STATE(86)] = 3597,
+  [SMALL_STATE(87)] = 3627,
+  [SMALL_STATE(88)] = 3657,
+  [SMALL_STATE(89)] = 3687,
+  [SMALL_STATE(90)] = 3707,
+  [SMALL_STATE(91)] = 3729,
+  [SMALL_STATE(92)] = 3749,
+  [SMALL_STATE(93)] = 3769,
+  [SMALL_STATE(94)] = 3789,
+  [SMALL_STATE(95)] = 3810,
+  [SMALL_STATE(96)] = 3839,
+  [SMALL_STATE(97)] = 3855,
+  [SMALL_STATE(98)] = 3877,
+  [SMALL_STATE(99)] = 3893,
+  [SMALL_STATE(100)] = 3911,
+  [SMALL_STATE(101)] = 3927,
+  [SMALL_STATE(102)] = 3943,
+  [SMALL_STATE(103)] = 3969,
+  [SMALL_STATE(104)] = 3991,
+  [SMALL_STATE(105)] = 4011,
+  [SMALL_STATE(106)] = 4027,
+  [SMALL_STATE(107)] = 4043,
+  [SMALL_STATE(108)] = 4059,
+  [SMALL_STATE(109)] = 4075,
+  [SMALL_STATE(110)] = 4091,
+  [SMALL_STATE(111)] = 4107,
+  [SMALL_STATE(112)] = 4123,
+  [SMALL_STATE(113)] = 4139,
+  [SMALL_STATE(114)] = 4155,
+  [SMALL_STATE(115)] = 4180,
+  [SMALL_STATE(116)] = 4205,
+  [SMALL_STATE(117)] = 4224,
+  [SMALL_STATE(118)] = 4239,
+  [SMALL_STATE(119)] = 4255,
+  [SMALL_STATE(120)] = 4271,
+  [SMALL_STATE(121)] = 4291,
+  [SMALL_STATE(122)] = 4307,
+  [SMALL_STATE(123)] = 4326,
+  [SMALL_STATE(124)] = 4345,
+  [SMALL_STATE(125)] = 4358,
+  [SMALL_STATE(126)] = 4371,
+  [SMALL_STATE(127)] = 4384,
+  [SMALL_STATE(128)] = 4397,
+  [SMALL_STATE(129)] = 4414,
+  [SMALL_STATE(130)] = 4433,
+  [SMALL_STATE(131)] = 4452,
+  [SMALL_STATE(132)] = 4471,
+  [SMALL_STATE(133)] = 4490,
+  [SMALL_STATE(134)] = 4509,
+  [SMALL_STATE(135)] = 4528,
+  [SMALL_STATE(136)] = 4541,
+  [SMALL_STATE(137)] = 4560,
+  [SMALL_STATE(138)] = 4573,
+  [SMALL_STATE(139)] = 4586,
+  [SMALL_STATE(140)] = 4599,
+  [SMALL_STATE(141)] = 4618,
+  [SMALL_STATE(142)] = 4637,
+  [SMALL_STATE(143)] = 4650,
+  [SMALL_STATE(144)] = 4663,
+  [SMALL_STATE(145)] = 4676,
+  [SMALL_STATE(146)] = 4695,
+  [SMALL_STATE(147)] = 4708,
+  [SMALL_STATE(148)] = 4723,
+  [SMALL_STATE(149)] = 4736,
+  [SMALL_STATE(150)] = 4752,
+  [SMALL_STATE(151)] = 4765,
+  [SMALL_STATE(152)] = 4780,
+  [SMALL_STATE(153)] = 4795,
+  [SMALL_STATE(154)] = 4808,
+  [SMALL_STATE(155)] = 4821,
+  [SMALL_STATE(156)] = 4834,
+  [SMALL_STATE(157)] = 4849,
+  [SMALL_STATE(158)] = 4859,
+  [SMALL_STATE(159)] = 4869,
+  [SMALL_STATE(160)] = 4879,
+  [SMALL_STATE(161)] = 4889,
+  [SMALL_STATE(162)] = 4902,
+  [SMALL_STATE(163)] = 4913,
+  [SMALL_STATE(164)] = 4924,
+  [SMALL_STATE(165)] = 4935,
+  [SMALL_STATE(166)] = 4948,
+  [SMALL_STATE(167)] = 4961,
+  [SMALL_STATE(168)] = 4974,
+  [SMALL_STATE(169)] = 4985,
+  [SMALL_STATE(170)] = 4996,
+  [SMALL_STATE(171)] = 5009,
+  [SMALL_STATE(172)] = 5022,
+  [SMALL_STATE(173)] = 5032,
+  [SMALL_STATE(174)] = 5042,
+  [SMALL_STATE(175)] = 5052,
+  [SMALL_STATE(176)] = 5062,
+  [SMALL_STATE(177)] = 5072,
+  [SMALL_STATE(178)] = 5082,
+  [SMALL_STATE(179)] = 5092,
+  [SMALL_STATE(180)] = 5102,
+  [SMALL_STATE(181)] = 5112,
+  [SMALL_STATE(182)] = 5122,
+  [SMALL_STATE(183)] = 5129,
+  [SMALL_STATE(184)] = 5136,
+  [SMALL_STATE(185)] = 5143,
+  [SMALL_STATE(186)] = 5150,
+  [SMALL_STATE(187)] = 5157,
+  [SMALL_STATE(188)] = 5164,
+  [SMALL_STATE(189)] = 5171,
+  [SMALL_STATE(190)] = 5178,
+  [SMALL_STATE(191)] = 5185,
+  [SMALL_STATE(192)] = 5192,
+  [SMALL_STATE(193)] = 5199,
+  [SMALL_STATE(194)] = 5206,
+  [SMALL_STATE(195)] = 5213,
+  [SMALL_STATE(196)] = 5220,
+  [SMALL_STATE(197)] = 5227,
+  [SMALL_STATE(198)] = 5234,
+  [SMALL_STATE(199)] = 5241,
+  [SMALL_STATE(200)] = 5248,
+  [SMALL_STATE(201)] = 5255,
+  [SMALL_STATE(202)] = 5262,
+  [SMALL_STATE(203)] = 5269,
+  [SMALL_STATE(204)] = 5276,
+  [SMALL_STATE(205)] = 5283,
+  [SMALL_STATE(206)] = 5290,
+  [SMALL_STATE(207)] = 5297,
+  [SMALL_STATE(208)] = 5304,
+  [SMALL_STATE(209)] = 5311,
+  [SMALL_STATE(210)] = 5318,
+  [SMALL_STATE(211)] = 5325,
+  [SMALL_STATE(212)] = 5332,
+  [SMALL_STATE(213)] = 5339,
+  [SMALL_STATE(214)] = 5346,
+  [SMALL_STATE(215)] = 5353,
+  [SMALL_STATE(216)] = 5360,
+  [SMALL_STATE(217)] = 5367,
+  [SMALL_STATE(218)] = 5374,
+  [SMALL_STATE(219)] = 5381,
+  [SMALL_STATE(220)] = 5388,
+  [SMALL_STATE(221)] = 5395,
+  [SMALL_STATE(222)] = 5402,
+  [SMALL_STATE(223)] = 5409,
+  [SMALL_STATE(224)] = 5416,
+  [SMALL_STATE(225)] = 5423,
+  [SMALL_STATE(226)] = 5430,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -7377,290 +8149,306 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 0, 0, 0),
-  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(78),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
-  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(143),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
-  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(159),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(190),
-  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
-  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
-  [43] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
+  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(94),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(170),
+  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(158),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
+  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(80),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(177),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(187),
+  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(214),
+  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
+  [43] = {.entry = {.count = 1, .reusable = false}}, SHIFT(77),
   [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1, 0, 0),
-  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0),
-  [49] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(71),
-  [52] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(63),
-  [55] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(147),
-  [58] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(148),
-  [61] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(27),
-  [64] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(21),
-  [67] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(155),
-  [70] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(157),
-  [73] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(158),
-  [76] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(159),
-  [79] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(161),
-  [82] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(162),
-  [85] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(190),
-  [88] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(188),
-  [91] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(163),
-  [94] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declarations, 1, 0, 0),
-  [96] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [98] = {.entry = {.count = 1, .reusable = false}}, SHIFT(38),
-  [100] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__not_interpolation, 1, 0, 0),
-  [102] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
+  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declarations, 1, 0, 0),
+  [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0),
+  [51] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(80),
+  [54] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(73),
+  [57] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(168),
+  [60] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(164),
+  [63] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(30),
+  [66] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(25),
+  [69] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(177),
+  [72] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(178),
+  [75] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(172),
+  [78] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(180),
+  [81] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(181),
+  [84] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(173),
+  [87] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(187),
+  [90] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(214),
+  [93] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declarations_repeat1, 2, 0, 0), SHIFT_REPEAT(176),
+  [96] = {.entry = {.count = 1, .reusable = false}}, SHIFT(117),
+  [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [100] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [102] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
   [104] = {.entry = {.count = 1, .reusable = false}}, SHIFT(163),
-  [106] = {.entry = {.count = 1, .reusable = false}}, SHIFT(154),
-  [108] = {.entry = {.count = 1, .reusable = false}}, SHIFT(102),
-  [110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
-  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__not_interpolation, 1, 0, 0),
-  [114] = {.entry = {.count = 1, .reusable = false}}, SHIFT(103),
-  [116] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [120] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
-  [122] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
-  [124] = {.entry = {.count = 1, .reusable = false}}, SHIFT(112),
-  [126] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
-  [128] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [130] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
-  [132] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [134] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [136] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(103),
-  [139] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(41),
-  [142] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(32),
-  [145] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(156),
-  [148] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(160),
-  [151] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(112),
-  [154] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(112),
-  [157] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0),
-  [159] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(77),
-  [162] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__optional_seq, 1, 0, 0),
-  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [166] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
-  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
-  [176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(204),
-  [178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
-  [180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
-  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(197),
-  [184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
-  [186] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
-  [188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
-  [190] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_seq, 2, 0, 0),
-  [192] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_seq_repeat1, 2, 0, 0), SHIFT_REPEAT(71),
-  [195] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_seq_repeat1, 2, 0, 0),
-  [197] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_seq_repeat1, 2, 0, 0), SHIFT_REPEAT(147),
-  [200] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_seq_repeat1, 2, 0, 0), SHIFT_REPEAT(148),
-  [203] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_seq_repeat1, 2, 0, 0), SHIFT_REPEAT(27),
-  [206] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_seq_repeat1, 2, 0, 0), SHIFT_REPEAT(21),
-  [209] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
-  [211] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2, 0, 0),
-  [213] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2, 0, 0),
-  [215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declaration, 1, 0, 0),
-  [217] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_declaration, 1, 0, 0),
-  [219] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_command_declaration, 3, 0, 4),
-  [221] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_command_declaration, 3, 0, 4),
-  [223] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_app_declaration, 3, 0, 4),
-  [225] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_app_declaration, 3, 0, 4),
-  [227] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_deck_declaration, 3, 0, 4),
-  [229] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_deck_declaration, 3, 0, 4),
-  [231] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assignment_statement, 4, 0, 4),
-  [233] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assignment_statement, 4, 0, 4),
-  [235] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_gamepad_declaration, 3, 0, 4),
-  [237] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_gamepad_declaration, 3, 0, 4),
-  [239] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_face_declaration, 3, 0, 4),
-  [241] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_face_declaration, 3, 0, 4),
-  [243] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_matches, 2, 0, 0),
-  [245] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_matches, 2, 0, 0),
-  [247] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_statement, 1, 0, 0),
-  [249] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_statement, 1, 0, 0),
-  [251] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__statements, 2, 0, 0),
-  [253] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__statements, 2, 0, 0),
-  [255] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 1, 0, 0),
-  [257] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 1, 0, 0),
-  [259] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag_import_declaration, 4, 0, 4),
-  [261] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag_import_declaration, 4, 0, 4),
-  [263] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_matches, 3, 0, 0),
-  [265] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_matches, 3, 0, 0),
-  [267] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_key_binding_declaration, 3, 0, 7),
-  [269] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_key_binding_declaration, 3, 0, 7),
-  [271] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression_statement, 2, 0, 9),
-  [273] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_expression_statement, 2, 0, 9),
-  [275] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parrot_declaration, 3, 0, 4),
-  [277] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parrot_declaration, 3, 0, 4),
-  [279] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__statements, 1, 0, 5),
-  [281] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__statements, 1, 0, 5),
-  [283] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_settings_declaration, 3, 0, 4),
-  [285] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_settings_declaration, 3, 0, 4),
-  [287] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_noise_declaration, 3, 0, 4),
-  [289] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_noise_declaration, 3, 0, 4),
-  [291] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_seq_repeat1, 1, 0, 0),
-  [293] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_seq_repeat1, 1, 0, 0),
-  [295] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_repeat1, 2, 0, 0),
-  [297] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_repeat1, 2, 0, 0),
-  [299] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_repeat, 2, 0, 0),
-  [301] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_repeat, 2, 0, 0),
-  [303] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parenthesized_rule, 3, 0, 0),
-  [305] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parenthesized_rule, 3, 0, 0),
-  [307] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list, 3, 0, 1),
-  [309] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list, 3, 0, 1),
-  [311] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_capture, 3, 0, 2),
-  [313] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_capture, 3, 0, 2),
-  [315] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_optional, 3, 0, 0),
-  [317] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_optional, 3, 0, 0),
-  [319] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_word, 1, 0, 0),
-  [321] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word, 1, 0, 0),
-  [323] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
-  [325] = {.entry = {.count = 1, .reusable = false}}, SHIFT(107),
-  [327] = {.entry = {.count = 1, .reusable = false}}, SHIFT(109),
-  [329] = {.entry = {.count = 1, .reusable = false}}, SHIFT(73),
-  [331] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
-  [333] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
-  [335] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2, 0, 0), SHIFT_REPEAT(5),
-  [338] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2, 0, 0), SHIFT_REPEAT(107),
-  [341] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2, 0, 0), SHIFT_REPEAT(109),
-  [344] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2, 0, 0), SHIFT_REPEAT(73),
-  [347] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_string_repeat1, 2, 0, 0), SHIFT_REPEAT(73),
-  [350] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_string_repeat1, 2, 0, 0),
-  [352] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
-  [354] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
-  [356] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
-  [358] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
-  [360] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier, 1, 0, 0),
-  [362] = {.entry = {.count = 1, .reusable = false}}, SHIFT(72),
-  [364] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [366] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
-  [368] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_word, 1, 0, 0), REDUCE(sym_identifier, 1, 0, 0),
-  [371] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
-  [373] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 1, 0, 6),
-  [375] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [377] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_matches_repeat1, 2, 0, 0), SHIFT_REPEAT(76),
-  [380] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_matches_repeat1, 2, 0, 0),
-  [382] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_matches_repeat1, 2, 0, 0), SHIFT_REPEAT(143),
-  [385] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
-  [387] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [389] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_key_action, 3, 0, 3),
-  [391] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [393] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_sleep_action, 3, 0, 3),
-  [395] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parenthesized_expression, 3, 0, 0),
-  [397] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binary_operator, 3, 0, 11),
-  [399] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [401] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [403] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
-  [405] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [407] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [409] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 2, 0, 0),
-  [411] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, 0, 0),
-  [413] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_action, 2, 0, 10),
-  [415] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 3, 0, 0),
-  [417] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 4, 0, 0),
-  [419] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 5, 0, 0),
-  [421] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unary_operator, 2, 0, 8),
-  [423] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 2, 0, 0),
-  [425] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 1, 0, 0),
-  [427] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
-  [429] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [431] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 3, 0, 0),
-  [433] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 3, 0, 0),
-  [435] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argument_list_repeat1, 2, 0, 0),
-  [437] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__escape_interpolation, 1, 0, 0),
-  [439] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__escape_interpolation, 1, 0, 0),
-  [441] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
-  [443] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [445] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [447] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [449] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
-  [451] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
-  [453] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [455] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [457] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
-  [459] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
-  [461] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_match_repeat1, 2, 0, 0),
-  [463] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_match_repeat1, 2, 0, 0), SHIFT_REPEAT(143),
-  [466] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__optional_anchor, 1, 0, 0),
-  [468] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
-  [470] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match, 5, 0, 12),
-  [472] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match, 5, 0, 12),
-  [474] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_choice, 2, 0, 0),
-  [476] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [478] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match, 4, 0, 4),
-  [480] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match, 4, 0, 4),
-  [482] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_choice_repeat1, 2, 0, 0),
-  [484] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_choice_repeat1, 2, 0, 0), SHIFT_REPEAT(42),
-  [487] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__optional_anchor, 2, 0, 0),
-  [489] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
-  [491] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__optional_choice, 1, 0, 0),
-  [493] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__optional_anchor, 3, 0, 0),
-  [495] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_modifier, 1, 0, 0),
-  [497] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
-  [499] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [501] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [503] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [505] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_matches_repeat2, 2, 0, 0), SHIFT_REPEAT(151),
-  [508] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_matches_repeat2, 2, 0, 0),
-  [510] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [512] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argument_list_repeat1, 2, 0, 0), SHIFT_REPEAT(39),
-  [515] = {.entry = {.count = 1, .reusable = false}}, SHIFT(194),
-  [517] = {.entry = {.count = 1, .reusable = false}}, SHIFT(185),
-  [519] = {.entry = {.count = 1, .reusable = false}}, SHIFT(189),
-  [521] = {.entry = {.count = 1, .reusable = false}}, SHIFT(195),
-  [523] = {.entry = {.count = 1, .reusable = false}}, SHIFT(199),
-  [525] = {.entry = {.count = 1, .reusable = false}}, SHIFT(200),
-  [527] = {.entry = {.count = 1, .reusable = false}}, SHIFT(196),
-  [529] = {.entry = {.count = 1, .reusable = false}}, SHIFT(201),
-  [531] = {.entry = {.count = 1, .reusable = false}}, SHIFT(203),
-  [533] = {.entry = {.count = 1, .reusable = false}}, SHIFT(205),
-  [535] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [537] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
-  [539] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
-  [541] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
-  [543] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
-  [545] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_face_binding, 3, 0, 3),
-  [547] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_deck_binding, 3, 0, 3),
-  [549] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_gamepad_binding, 3, 0, 3),
-  [551] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
-  [553] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [555] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [557] = {.entry = {.count = 1, .reusable = false}}, SHIFT(193),
-  [559] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [561] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [563] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [565] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [567] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_noise_binding, 3, 0, 3),
-  [569] = {.entry = {.count = 1, .reusable = false}}, SHIFT(187),
-  [571] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_rule, 1, 0, 0),
-  [573] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [575] = {.entry = {.count = 1, .reusable = true}}, SHIFT(192),
-  [577] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [579] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
-  [581] = {.entry = {.count = 1, .reusable = true}}, SHIFT(149),
-  [583] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
-  [585] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [587] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parrot_binding, 3, 0, 3),
-  [589] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_app_binding, 3, 0, 3),
-  [591] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
-  [593] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
-  [595] = {.entry = {.count = 1, .reusable = true}}, SHIFT(170),
-  [597] = {.entry = {.count = 1, .reusable = true}}, SHIFT(116),
-  [599] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
-  [601] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
-  [603] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
-  [605] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
-  [607] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [609] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
-  [611] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
-  [613] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 2, 0, 0),
+  [106] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
+  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
+  [110] = {.entry = {.count = 1, .reusable = false}}, SHIFT(143),
+  [112] = {.entry = {.count = 1, .reusable = true}}, SHIFT(143),
+  [114] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [116] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [118] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
+  [120] = {.entry = {.count = 1, .reusable = false}}, SHIFT(169),
+  [122] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [126] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(117),
+  [129] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(38),
+  [132] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(40),
+  [135] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(49),
+  [138] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(163),
+  [141] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(175),
+  [144] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(179),
+  [147] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(143),
+  [150] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(143),
+  [153] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0),
+  [155] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(85),
+  [158] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [160] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
+  [162] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__not_interpolation, 1, 0, 0),
+  [164] = {.entry = {.count = 1, .reusable = false}}, SHIFT(47),
+  [166] = {.entry = {.count = 1, .reusable = false}}, SHIFT(176),
+  [168] = {.entry = {.count = 1, .reusable = false}}, SHIFT(174),
+  [170] = {.entry = {.count = 1, .reusable = false}}, SHIFT(100),
+  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
+  [174] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__not_interpolation, 1, 0, 0),
+  [176] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__optional_seq, 1, 0, 0),
+  [178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [186] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
+  [188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
+  [190] = {.entry = {.count = 1, .reusable = true}}, SHIFT(221),
+  [192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
+  [194] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
+  [196] = {.entry = {.count = 1, .reusable = true}}, SHIFT(210),
+  [198] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_seq_repeat1, 2, 0, 0), SHIFT_REPEAT(80),
+  [201] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_seq_repeat1, 2, 0, 0),
+  [203] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_seq_repeat1, 2, 0, 0), SHIFT_REPEAT(168),
+  [206] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_seq_repeat1, 2, 0, 0), SHIFT_REPEAT(164),
+  [209] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_seq_repeat1, 2, 0, 0), SHIFT_REPEAT(30),
+  [212] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_seq_repeat1, 2, 0, 0), SHIFT_REPEAT(25),
+  [215] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
+  [217] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
+  [219] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_seq, 2, 0, 0),
+  [221] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
+  [223] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
+  [225] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_gamepad_declaration, 3, 0, 4),
+  [227] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_gamepad_declaration, 3, 0, 4),
+  [229] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_matches, 3, 0, 0),
+  [231] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_matches, 3, 0, 0),
+  [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declaration, 1, 0, 0),
+  [235] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_declaration, 1, 0, 0),
+  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_settings_declaration, 3, 0, 4),
+  [239] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_settings_declaration, 3, 0, 4),
+  [241] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2, 0, 0),
+  [243] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2, 0, 0),
+  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag_import_declaration, 4, 0, 4),
+  [247] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag_import_declaration, 4, 0, 4),
+  [249] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 4, 0, 13),
+  [251] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 4, 0, 13),
+  [253] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression_statement, 2, 0, 9),
+  [255] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_expression_statement, 2, 0, 9),
+  [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assignment_statement, 4, 0, 4),
+  [259] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assignment_statement, 4, 0, 4),
+  [261] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__statements, 2, 0, 0),
+  [263] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__statements, 2, 0, 0),
+  [265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 1, 0, 0),
+  [267] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 1, 0, 0),
+  [269] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_matches, 2, 0, 0),
+  [271] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_matches, 2, 0, 0),
+  [273] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_key_binding_declaration, 3, 0, 7),
+  [275] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_key_binding_declaration, 3, 0, 7),
+  [277] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parrot_declaration, 3, 0, 4),
+  [279] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parrot_declaration, 3, 0, 4),
+  [281] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_noise_declaration, 3, 0, 4),
+  [283] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_noise_declaration, 3, 0, 4),
+  [285] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_deck_declaration, 3, 0, 4),
+  [287] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_deck_declaration, 3, 0, 4),
+  [289] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_face_declaration, 3, 0, 4),
+  [291] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_face_declaration, 3, 0, 4),
+  [293] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_app_declaration, 3, 0, 4),
+  [295] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_app_declaration, 3, 0, 4),
+  [297] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 6, 0, 14),
+  [299] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 6, 0, 14),
+  [301] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_command_declaration, 3, 0, 4),
+  [303] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_command_declaration, 3, 0, 4),
+  [305] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_statement, 1, 0, 0),
+  [307] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_statement, 1, 0, 0),
+  [309] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__statements, 1, 0, 5),
+  [311] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__statements, 1, 0, 5),
+  [313] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_repeat1, 2, 0, 0),
+  [315] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_repeat1, 2, 0, 0),
+  [317] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list, 3, 0, 1),
+  [319] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list, 3, 0, 1),
+  [321] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_repeat, 2, 0, 0),
+  [323] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_repeat, 2, 0, 0),
+  [325] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier, 1, 0, 0),
+  [327] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_seq_repeat1, 1, 0, 0),
+  [329] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_seq_repeat1, 1, 0, 0),
+  [331] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parenthesized_rule, 3, 0, 0),
+  [333] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parenthesized_rule, 3, 0, 0),
+  [335] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_word, 1, 0, 0),
+  [337] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_word, 1, 0, 0),
+  [339] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_optional, 3, 0, 0),
+  [341] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_optional, 3, 0, 0),
+  [343] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_capture, 3, 0, 2),
+  [345] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_capture, 3, 0, 2),
+  [347] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
+  [349] = {.entry = {.count = 1, .reusable = false}}, SHIFT(119),
+  [351] = {.entry = {.count = 1, .reusable = false}}, SHIFT(121),
+  [353] = {.entry = {.count = 1, .reusable = false}}, SHIFT(87),
+  [355] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [357] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
+  [359] = {.entry = {.count = 1, .reusable = false}}, SHIFT(88),
+  [361] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
+  [363] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
+  [365] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2, 0, 0), SHIFT_REPEAT(17),
+  [368] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2, 0, 0), SHIFT_REPEAT(119),
+  [371] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2, 0, 0), SHIFT_REPEAT(121),
+  [374] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2, 0, 0), SHIFT_REPEAT(86),
+  [377] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_string_repeat1, 2, 0, 0), SHIFT_REPEAT(86),
+  [380] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_string_repeat1, 2, 0, 0),
+  [382] = {.entry = {.count = 1, .reusable = false}}, SHIFT(86),
+  [384] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [386] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
+  [388] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
+  [390] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 1, 0, 6),
+  [392] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [394] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_word, 1, 0, 0), REDUCE(sym_identifier, 1, 0, 0),
+  [397] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
+  [399] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 3, 0, 0),
+  [401] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [403] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [405] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 2, 0, 0),
+  [407] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binary_operator, 3, 0, 11),
+  [409] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [411] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 1, 0, 0),
+  [413] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parenthesized_expression, 3, 0, 0),
+  [415] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_matches_repeat1, 2, 0, 0), SHIFT_REPEAT(77),
+  [418] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_matches_repeat1, 2, 0, 0),
+  [420] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_matches_repeat1, 2, 0, 0), SHIFT_REPEAT(158),
+  [423] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [425] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [427] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 2, 0, 0),
+  [429] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_sleep_action, 3, 0, 3),
+  [431] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, 0, 0),
+  [433] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_action, 2, 0, 10),
+  [435] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_key_action, 3, 0, 3),
+  [437] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 4, 0, 0),
+  [439] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unary_operator, 2, 0, 8),
+  [441] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 5, 0, 0),
+  [443] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
+  [445] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [447] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [449] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
+  [451] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [453] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 3, 0, 0),
+  [455] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 3, 0, 0),
+  [457] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argument_list_repeat1, 2, 0, 0),
+  [459] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__escape_interpolation, 1, 0, 0),
+  [461] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__escape_interpolation, 1, 0, 0),
+  [463] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [465] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [467] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [469] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [471] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
+  [473] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
+  [475] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [477] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
+  [479] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [481] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
+  [483] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [485] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [487] = {.entry = {.count = 1, .reusable = true}}, SHIFT(118),
+  [489] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [491] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_match_repeat1, 2, 0, 0),
+  [493] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_match_repeat1, 2, 0, 0), SHIFT_REPEAT(158),
+  [496] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__optional_anchor, 1, 0, 0),
+  [498] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
+  [500] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_choice_repeat1, 2, 0, 0),
+  [502] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_choice_repeat1, 2, 0, 0), SHIFT_REPEAT(50),
+  [505] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__optional_choice, 1, 0, 0),
+  [507] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [509] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match, 4, 0, 4),
+  [511] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match, 4, 0, 4),
+  [513] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__optional_anchor, 2, 0, 0),
+  [515] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
+  [517] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match, 5, 0, 12),
+  [519] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match, 5, 0, 12),
+  [521] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_choice, 2, 0, 0),
+  [523] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__optional_anchor, 3, 0, 0),
+  [525] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_modifier, 1, 0, 0),
+  [527] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [529] = {.entry = {.count = 1, .reusable = true}}, SHIFT(167),
+  [531] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [533] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [535] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_matches_repeat2, 2, 0, 0), SHIFT_REPEAT(167),
+  [538] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_matches_repeat2, 2, 0, 0),
+  [540] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
+  [542] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argument_list_repeat1, 2, 0, 0), SHIFT_REPEAT(36),
+  [545] = {.entry = {.count = 1, .reusable = false}}, SHIFT(202),
+  [547] = {.entry = {.count = 1, .reusable = false}}, SHIFT(198),
+  [549] = {.entry = {.count = 1, .reusable = false}}, SHIFT(206),
+  [551] = {.entry = {.count = 1, .reusable = false}}, SHIFT(201),
+  [553] = {.entry = {.count = 1, .reusable = false}}, SHIFT(196),
+  [555] = {.entry = {.count = 1, .reusable = false}}, SHIFT(204),
+  [557] = {.entry = {.count = 1, .reusable = false}}, SHIFT(203),
+  [559] = {.entry = {.count = 1, .reusable = false}}, SHIFT(197),
+  [561] = {.entry = {.count = 1, .reusable = false}}, SHIFT(200),
+  [563] = {.entry = {.count = 1, .reusable = false}}, SHIFT(182),
+  [565] = {.entry = {.count = 1, .reusable = true}}, SHIFT(205),
+  [567] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
+  [569] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_gamepad_binding, 3, 0, 3),
+  [571] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_deck_binding, 3, 0, 3),
+  [573] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_face_binding, 3, 0, 3),
+  [575] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [577] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_app_binding, 3, 0, 3),
+  [579] = {.entry = {.count = 1, .reusable = true}}, SHIFT(207),
+  [581] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_rule, 1, 0, 0),
+  [583] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [585] = {.entry = {.count = 1, .reusable = false}}, SHIFT(218),
+  [587] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [589] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 2, 0, 0),
+  [591] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
+  [593] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
+  [595] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
+  [597] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [599] = {.entry = {.count = 1, .reusable = true}}, SHIFT(184),
+  [601] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
+  [603] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
+  [605] = {.entry = {.count = 1, .reusable = true}}, SHIFT(186),
+  [607] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
+  [609] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_noise_binding, 3, 0, 3),
+  [611] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
+  [613] = {.entry = {.count = 1, .reusable = false}}, SHIFT(208),
+  [615] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
+  [617] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [619] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
+  [621] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parrot_binding, 3, 0, 3),
+  [623] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [625] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
+  [627] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [629] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [631] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [633] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
+  [635] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [637] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [639] = {.entry = {.count = 1, .reusable = true}}, SHIFT(192),
+  [641] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [643] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [645] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [647] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
 };
 
 enum ts_external_scanner_symbol_identifiers {
@@ -7697,19 +8485,19 @@ static const bool ts_external_scanner_states[9][EXTERNAL_TOKEN_COUNT] = {
     [ts_external_token_comment] = true,
   },
   [3] = {
-    [ts_external_token__string_start] = true,
-    [ts_external_token_string_content] = true,
-    [ts_external_token__string_end] = true,
-    [ts_external_token_comment] = true,
-  },
-  [4] = {
     [ts_external_token__dedent] = true,
     [ts_external_token__string_start] = true,
     [ts_external_token_comment] = true,
   },
-  [5] = {
+  [4] = {
     [ts_external_token__indent] = true,
     [ts_external_token__string_start] = true,
+    [ts_external_token_comment] = true,
+  },
+  [5] = {
+    [ts_external_token__string_start] = true,
+    [ts_external_token_string_content] = true,
+    [ts_external_token__string_end] = true,
     [ts_external_token_comment] = true,
   },
   [6] = {

--- a/test/corpus/beta.txt
+++ b/test/corpus/beta.txt
@@ -1,0 +1,60 @@
+================================================================================
+BETA: if statement
+================================================================================
+
+command:
+    if true: print("true")
+    if false: print("false")
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declarations
+    (command_declaration
+      left: (rule
+        (word))
+      right: (block
+        (if_statement
+          condition: (variable
+            variable_name: (identifier))
+          body: (expression_statement
+            expression: (action
+              action_name: (identifier)
+              arguments: (argument_list
+                (string
+                  (string_content))))))
+        (if_statement
+          condition: (variable
+            variable_name: (identifier))
+          body: (expression_statement
+            expression: (action
+              action_name: (identifier)
+              arguments: (argument_list
+                (string
+                  (string_content))))))))))
+
+================================================================================
+BETA: for loop
+================================================================================
+
+command:
+    for a in "test": print(a)
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declarations
+    (command_declaration
+      left: (rule
+        (word))
+      right: (block
+        (for_statement
+          name: (identifier)
+          value: (string
+            (string_content))
+          body: (expression_statement
+            expression: (action
+              action_name: (identifier)
+              arguments: (argument_list
+                (variable
+                  variable_name: (identifier))))))))))

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -1,20 +1,43 @@
-const { beforeEach, describe, expect, it } = require('@jest/globals');
-const { fetchAllTestData, getTestModes, createParser } = require('./common.js');
-const fs = require('fs');
+const { beforeEach, describe, expect, it } = require("@jest/globals");
+const { fetchAllTestData, getTestModes, createParser } = require("./common.js");
+const fs = require("fs");
+const path = require("path");
 
 const MODES = getTestModes();
 const TEST_DATA = fetchAllTestData();
 const TEST_DIRS = Object.keys(TEST_DATA);
 
-describe.each(MODES)('examples [%s]', (mode) => {
+const SKIPPED_EXAMPLE_FILES = new Set([
+  // Swedish dictation using google web speech has syntax not supported by Talon conformer and a current parser.
+  "AndreasArvidsson/andreas-talon/core/modes/dictation_mode_sv.talon",
+]);
+
+function shouldSkipExampleFile(testFile) {
+  return SKIPPED_EXAMPLE_FILES.has(testFile.replaceAll("\\", "/"));
+}
+
+function getRelativeTestPath(testDir, testFile) {
+  const testsDir = path.dirname(path.dirname(testDir));
+  return path.relative(testsDir, testFile);
+}
+
+describe.each(MODES)("examples [%s]", (mode) => {
   let parser;
-  beforeEach(async () => { parser = await createParser(mode) });
-  describe.each(TEST_DIRS)('%s', (testDir) => {
-    const testFiles = TEST_DATA[testDir];
-    it.each(testFiles)('%s', (testFile) => {
-      const sourceCode = fs.readFileSync(testFile, 'utf8')
+
+  beforeEach(async () => {
+    parser = await createParser(mode);
+  });
+
+  describe.each(TEST_DIRS)("%s", (testDir) => {
+    const testFiles = TEST_DATA[testDir]
+      .map((testFile) => [getRelativeTestPath(testDir, testFile), testFile])
+      .filter(([relativePath]) => !shouldSkipExampleFile(relativePath));
+
+    it.each(testFiles)("%s", (relativePath, testFile) => {
+      const sourceCode = fs.readFileSync(testFile, "utf8");
       const tree = parser.parse(sourceCode);
       expect(tree).toBeDefined();
+      expect(tree.rootNode.hasError).toBe(false);
     });
   });
 });

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -7,13 +7,13 @@ const MODES = getTestModes();
 const TEST_DATA = fetchAllTestData();
 const TEST_DIRS = Object.keys(TEST_DATA);
 
-const SKIPPED_EXAMPLE_FILES = new Set([
+const ERRORING_EXAMPLE_FILES = new Set([
   // Swedish dictation using google web speech has syntax not supported by Talon conformer and a current parser.
   "AndreasArvidsson/andreas-talon/core/modes/dictation_mode_sv.talon",
 ]);
 
-function shouldSkipExampleFile(testFile) {
-  return SKIPPED_EXAMPLE_FILES.has(testFile.replaceAll("\\", "/"));
+function fileHasExpectedError(testFile) {
+  return ERRORING_EXAMPLE_FILES.has(testFile.replaceAll("\\", "/"));
 }
 
 function getRelativeTestPath(testDir, testFile) {
@@ -29,15 +29,19 @@ describe.each(MODES)("examples [%s]", (mode) => {
   });
 
   describe.each(TEST_DIRS)("%s", (testDir) => {
-    const testFiles = TEST_DATA[testDir]
-      .map((testFile) => [getRelativeTestPath(testDir, testFile), testFile])
-      .filter(([relativePath]) => !shouldSkipExampleFile(relativePath));
+    const testFiles = TEST_DATA[testDir].map((testFile) => [
+      getRelativeTestPath(testDir, testFile),
+      testFile,
+    ]);
 
     it.each(testFiles)("%s", (relativePath, testFile) => {
       const sourceCode = fs.readFileSync(testFile, "utf8");
       const tree = parser.parse(sourceCode);
       expect(tree).toBeDefined();
-      expect(tree.rootNode.hasError).toBe(false);
+
+      if (!fileHasExpectedError(relativePath)) {
+        expect(tree.rootNode.hasError).toBe(false);
+      }
     });
   });
 });


### PR DESCRIPTION
* Add support for if and for statements in Talon script
* Updated example repositories to latest commit sha
* Updated example test code to assert that parse tree has no errors
* Updated outdated readme instructions on how to add new example repositories 
* Updated git attributes to specify that crlf.txt should use eol crlf

Fixes #64